### PR TITLE
Updated sign-in to involve registration for first time Users

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,3 +93,5 @@ fabric.properties
 
 /ingest-ui.iml
 /private.yml
+
+client/src/environments/local

--- a/client/angular.json
+++ b/client/angular.json
@@ -26,6 +26,14 @@
             "scripts": []
           },
           "configurations": {
+            "local": {
+              "fileReplacements": [
+                {
+                  "replace": "src/environments/environment.ts",
+                  "with": "src/environments/local/environment.ts"
+                }
+              ]
+            },
             "testing": {
               "fileReplacements": [
                 {
@@ -100,6 +108,9 @@
             "browserTarget": "ingest-ui:build"
           },
           "configurations": {
+            "local": {
+              "browserTarget": "ingest-ui:build:local"
+            },
             "testing": {
               "browserTarget": "ingest-ui:build:testing"
             },

--- a/client/karma.conf.js
+++ b/client/karma.conf.js
@@ -4,6 +4,9 @@
 module.exports = function (config) {
   config.set({
     basePath: '',
+    files: [
+      { pattern: './src/app/core/*.spec.ts' }
+    ],
     frameworks: ['jasmine', '@angular-devkit/build-angular'],
     plugins: [
       require('karma-jasmine'),

--- a/client/src/app/aai/aai.module.ts
+++ b/client/src/app/aai/aai.module.ts
@@ -1,0 +1,26 @@
+import {NgModule} from "@angular/core";
+import {CoreSecurity} from "../core/security.module";
+import {UserManager, WebStorageStateStore} from "oidc-client";
+import {environment} from "../../environments/environment";
+
+const userManager = new UserManager({
+  authority: environment.AAI_AUTHORITY,
+  client_id: environment.AAI_CLIENT_ID,
+  redirect_uri: window.location.origin + '/aai-callback',
+  post_logout_redirect_uri: window.location.origin,
+  response_type: 'token id_token',
+  scope: 'email openid profile',
+  filterProtocolClaims: true,
+  loadUserInfo: true,
+  userStore: new WebStorageStateStore({store: window.localStorage})
+});
+
+@NgModule({
+  imports: [CoreSecurity],
+  providers: [
+    {
+      provide: UserManager, useValue: userManager,
+    }
+  ]
+})
+export class AaiSecurity{}

--- a/client/src/app/aai/aai.service.spec.ts
+++ b/client/src/app/aai/aai.service.spec.ts
@@ -52,37 +52,41 @@ describe('Complete Authentication', () =>{
     aaiService = TestBed.get(AaiService);
   });
 
-  function signInToAai() {
-    userManager.getUser.and.returnValue(Observable.of(user).toPromise());
-    userManager.signinRedirectCallback.and.returnValue(Observable.of(user).toPromise());
-  }
-
   it('should redirect home when the user is registered', async(() => {
     //given:
-    signInToAai();
+    signInToRemoteService();
 
     //and:
     authenticationService.getAccount.and.returnValue(Observable.of(<Account>{}).toPromise());
 
     //expect:
     aaiService.completeAuthentication().then(() => {
+      expect(authenticationService.getAccount).toHaveBeenCalledWith(user.access_token);
+      expect(router.navigate).toHaveBeenCalledTimes(1);
       expect(router.navigate).toHaveBeenCalledWith(['/home']);
+      expect(aaiService.user$.getValue()).toBe(user);
     });
   }));
 
   it('should redirect to registration page when User has not registered yet', async(() => {
     //given:
-    signInToAai();
+    signInToRemoteService();
 
     //and:
     authenticationService.getAccount.and.returnValue(Promise.reject());
 
     //expect:
     aaiService.completeAuthentication().then(() => {
-      expect(router.navigate).toHaveBeenCalledWith(['/registration']);
       expect(authenticationService.getAccount).toHaveBeenCalledWith(user.access_token);
+      expect(router.navigate).toHaveBeenCalledTimes(1);
+      expect(router.navigate).toHaveBeenCalledWith(['/registration']);
       expect(aaiService.user$.getValue()).toBe(user);
     });
   }));
+
+  function signInToRemoteService() {
+    userManager.getUser.and.returnValue(Observable.of(user).toPromise());
+    userManager.signinRedirectCallback.and.returnValue(Observable.of(user).toPromise());
+  }
 
 });

--- a/client/src/app/aai/aai.service.spec.ts
+++ b/client/src/app/aai/aai.service.spec.ts
@@ -1,8 +1,71 @@
+import {AaiService} from "./aai.service";
+import {fakeAsync, TestBed} from "@angular/core/testing";
+import {AuthenticationService} from "../core/authentication.service";
+import {User, UserManager, UserSettings} from "oidc-client";
+import {HttpClientTestingModule} from "@angular/common/http/testing";
+import {AlertService} from "../shared/services/alert.service";
+import {RouterTestingModule} from "@angular/router/testing";
+import SpyObj = jasmine.SpyObj;
+import {Observable} from "rxjs";
+import {Router} from "@angular/router";
+
 describe('Complete Authentication', () =>{
 
-  it('should redirect home when the user is registered');
+  let aaiService: AaiService;
+
+  let authenticationService: SpyObj<AuthenticationService>;
+  let userManager: SpyObj<UserManager>;
+  let alertService: SpyObj<AlertService>;
+  let router: SpyObj<Router>;
+
+  const user: User = {
+    access_token: '98cbcb1',
+    id_token: '3762dd9',
+    expired: false,
+    expires_at: 0,
+    expires_in: 0,
+    profile: undefined,
+    scope: 'profile',
+    scopes: [],
+    state: undefined,
+    token_type: 'access',
+    toStorageString: () => '',
+  }
+
+  beforeEach(() => {
+    authenticationService = jasmine.createSpyObj('AuthenticationService', ['getAccount']);
+    userManager = jasmine.createSpyObj('UserManager', ['getUser', 'signinRedirectCallback'])
+    alertService = jasmine.createSpyObj('AlertService', ['error']);
+    router = jasmine.createSpyObj('Router', ['navigate']);
+
+    TestBed.configureTestingModule({
+      providers: [
+        AaiService,
+        {provide: AuthenticationService, useFactory: () => authenticationService},
+        {provide: UserManager, useFactory: () => userManager},
+        {provide: AlertService, useValue: alertService},
+        {provide: Router, useFactory: () => router},
+      ],
+      imports: [HttpClientTestingModule],
+    });
+
+    aaiService = TestBed.get(AaiService);
+  });
+
+  it('should redirect home when the user is registered', fakeAsync(() => {
+    //given:
+    userManager.getUser.and.returnValue(Observable.of(user).toPromise());
+    userManager.signinRedirectCallback.and.returnValue(Observable.of(user).toPromise());
+
+    //and:
+    authenticationService.getAccount.and.returnValue(Observable.of({}).toPromise());
+
+    //expect:
+    aaiService.completeAuthentication().then(() => {
+      expect(router.navigate).toHaveBeenCalled();
+    });
+  }));
 
   it('should redirect to registration page when User has not registered yet');
 
 });
-

--- a/client/src/app/aai/aai.service.spec.ts
+++ b/client/src/app/aai/aai.service.spec.ts
@@ -1,0 +1,8 @@
+describe('Complete Authentication', () =>{
+
+  it('should redirect home when the user is registered');
+
+  it('should redirect to registration page when User has not registered yet');
+
+});
+

--- a/client/src/app/aai/aai.service.ts
+++ b/client/src/app/aai/aai.service.ts
@@ -1,38 +1,25 @@
-import {Profile, User, UserManager, UserManagerSettings, WebStorageStateStore} from 'oidc-client';
+import {Profile, User, UserManager} from 'oidc-client';
 import {Injectable} from '@angular/core';
 import {BehaviorSubject, from, Observable, Subject} from 'rxjs';
 import {HttpClient} from '@angular/common/http';
 import {AlertService} from '../shared/services/alert.service';
 import {Router} from '@angular/router';
-import {environment} from '../../environments/environment';
-
-export function getClientSettings(): UserManagerSettings {
-  return {
-    authority: environment.AAI_AUTHORITY,
-    client_id: environment.AAI_CLIENT_ID,
-    redirect_uri: window.location.origin + '/aai-callback',
-    post_logout_redirect_uri: window.location.origin,
-    response_type: 'token id_token',
-    scope: 'email openid profile',
-    filterProtocolClaims: true,
-    loadUserInfo: true,
-    userStore: new WebStorageStateStore({store: window.localStorage})
-  };
-}
+import {AuthenticationService} from "../core/authentication.service";
+import {AaiSecurity} from "./aai.module";
 
 @Injectable({
-  providedIn: 'root'
+  providedIn: AaiSecurity,
 })
 export class AaiService {
 
   public user$: BehaviorSubject<User> = new BehaviorSubject<User>(null);
-  private manager = new UserManager(getClientSettings());
-  private user: User = null;
+    private user: User = null;
 
   constructor(private http: HttpClient,
+              private manager: UserManager,
               private alertService: AlertService,
+              private authenticationService: AuthenticationService,
               private router: Router) {
-
     this.user$.subscribe(usr => {
       this.user = usr;
     });
@@ -74,6 +61,7 @@ export class AaiService {
 
   completeAuthentication(): Promise<void> {
     return this.manager.signinRedirectCallback().then(user => {
+      this.authenticationService.getAccount('');
       this.user = user;
       this.user$.next(user);
       this.router.navigate(['/home']);
@@ -96,4 +84,5 @@ export class AaiService {
   logout() {
     this.manager.signoutRedirect();
   }
+
 }

--- a/client/src/app/aai/aai.service.ts
+++ b/client/src/app/aai/aai.service.ts
@@ -60,8 +60,10 @@ export class AaiService {
   }
 
   completeAuthentication(): Promise<void> {
-    return this.manager.signinRedirectCallback().then(user => {
-      this.authenticationService.getAccount('');
+    return this.manager.signinRedirectCallback().then((user: User) => {
+      this.authenticationService.getAccount(user.access_token).catch(() => {
+        this.router.navigate(['/registration']);
+      });
       this.user = user;
       this.user$.next(user);
       this.router.navigate(['/home']);

--- a/client/src/app/aai/aai.service.ts
+++ b/client/src/app/aai/aai.service.ts
@@ -61,12 +61,15 @@ export class AaiService {
 
   completeAuthentication(): Promise<void> {
     return this.manager.signinRedirectCallback().then((user: User) => {
-      this.authenticationService.getAccount(user.access_token).catch(() => {
-        this.router.navigate(['/registration']);
-      });
       this.user = user;
       this.user$.next(user);
-      this.router.navigate(['/home']);
+      this.authenticationService.getAccount(user.access_token)
+        .then(() => {
+          this.router.navigate(['/home']);
+        })
+        .catch(() => {
+          this.router.navigate(['/registration']);
+        });
     }).catch(error => {
       this.alertService.error('Authentication Error',
         'An error occured during authentication. Please retry logging in. ' +

--- a/client/src/app/aai/aai.service.ts
+++ b/client/src/app/aai/aai.service.ts
@@ -1,6 +1,6 @@
 import {Profile, User, UserManager, UserManagerSettings, WebStorageStateStore} from 'oidc-client';
 import {Injectable} from '@angular/core';
-import {from, Observable, Subject, throwError} from 'rxjs';
+import {BehaviorSubject, from, Observable, Subject} from 'rxjs';
 import {HttpClient} from '@angular/common/http';
 import {AlertService} from '../shared/services/alert.service';
 import {Router} from '@angular/router';
@@ -25,18 +25,16 @@ export function getClientSettings(): UserManagerSettings {
 })
 export class AaiService {
 
+  public user$: BehaviorSubject<User> = new BehaviorSubject<User>(null);
   private manager = new UserManager(getClientSettings());
   private user: User = null;
-  private user$: Subject<User>;
 
   constructor(private http: HttpClient,
               private alertService: AlertService,
               private router: Router) {
 
-    this.user$ = new Subject<User>();
-    this.getUser().subscribe(user => {
-      this.user$.next(user);
-      this.user = user;
+    this.user$.subscribe(usr => {
+      this.user = usr;
     });
   }
 
@@ -45,7 +43,10 @@ export class AaiService {
   }
 
   getUser(): Observable<User> {
-    return from(this.manager.getUser());
+    return from(this.manager.getUser()).map(user => {
+      this.user$.next(user);
+      return user;
+    });
   }
 
   isUserLoggedIn(): Observable<boolean> {

--- a/client/src/app/aai/auth-guard.service.ts
+++ b/client/src/app/aai/auth-guard.service.ts
@@ -3,9 +3,10 @@ import {AaiService} from './aai.service';
 import {ActivatedRouteSnapshot, CanActivate, Router, RouterStateSnapshot, UrlTree} from '@angular/router';
 import {Observable} from 'rxjs';
 import {map} from 'rxjs/operators';
+import {AaiSecurity} from "./aai.module";
 
 @Injectable({
-  providedIn: 'root'
+  providedIn: AaiSecurity,
 })
 export class AuthGuardService implements CanActivate {
 

--- a/client/src/app/aai/oidc-interceptor.ts
+++ b/client/src/app/aai/oidc-interceptor.ts
@@ -1,11 +1,12 @@
-import { Injectable } from '@angular/core';
+import {Injectable} from '@angular/core';
 import {HttpEvent, HttpHandler, HttpInterceptor, HttpRequest} from '@angular/common/http';
 import {AaiService} from './aai.service';
 import {Observable} from 'rxjs';
 import {environment} from '../../environments/environment';
+import {AaiSecurity} from "./aai.module";
 
 @Injectable({
-  providedIn: 'root'
+  providedIn: AaiSecurity,
 })
 export class OidcInterceptor implements HttpInterceptor {
   constructor(private aai: AaiService) {}

--- a/client/src/app/app.module.ts
+++ b/client/src/app/app.module.ts
@@ -68,6 +68,7 @@ import {AaiCallbackComponent} from './aai-callback/aai-callback.component';
 import {OidcInterceptor} from './aai/oidc-interceptor';
 import {MaterialDesignFrameworkModule} from '@ajsf/material';
 import {AaiSecurity} from "./aai/aai.module";
+import { RegistrationComponent } from './registration/registration.component';
 
 
 @NgModule({
@@ -93,7 +94,8 @@ import {AaiSecurity} from "./aai/aai.module";
     AlertComponent,
     AaiCallbackComponent,
     ProjectFormComponent,
-    MyProjectsComponent
+    MyProjectsComponent,
+    RegistrationComponent
   ],
   imports: [
     NgbModule.forRoot(),

--- a/client/src/app/app.module.ts
+++ b/client/src/app/app.module.ts
@@ -67,6 +67,7 @@ import {SchemaService} from './shared/services/schema.service';
 import {AaiCallbackComponent} from './aai-callback/aai-callback.component';
 import {OidcInterceptor} from './aai/oidc-interceptor';
 import {MaterialDesignFrameworkModule} from '@ajsf/material';
+import {AaiSecurity} from "./aai/aai.module";
 
 
 @NgModule({
@@ -123,7 +124,8 @@ import {MaterialDesignFrameworkModule} from '@ajsf/material';
     MatProgressBarModule,
     MatProgressSpinnerModule,
     MatRadioModule,
-    MaterialDesignFrameworkModule
+    MaterialDesignFrameworkModule,
+    AaiSecurity,
   ],
   providers: [
     {

--- a/client/src/app/app.routes.ts
+++ b/client/src/app/app.routes.ts
@@ -8,6 +8,7 @@ import {AuthGuardService} from './aai/auth-guard.service';
 import {ProjectFormComponent} from "./submitter/project-form/project-form.component";
 import {MyProjectsComponent} from './submitter/my-projects/my-projects.component';
 import {SubmissionListComponent} from './submission-list/submission-list.component';
+import {RegistrationComponent} from "./registration/registration.component";
 
 export const ROUTES: Routes = [
   {path: 'login', component: LoginComponent},
@@ -29,6 +30,8 @@ export const ROUTES: Routes = [
   {path: 'projects', component: MyProjectsComponent,  canActivate: [AuthGuardService]},
   {path: 'projects/new', component: ProjectFormComponent,  canActivate: [AuthGuardService]},
   {path: 'projects/:uuid', component: ProjectFormComponent,  canActivate: [AuthGuardService]},
+
+  {path: 'registration', component: RegistrationComponent},
 
   {path: '**', redirectTo: ''}
 ];

--- a/client/src/app/core/authentication.service.spec.ts
+++ b/client/src/app/core/authentication.service.spec.ts
@@ -16,6 +16,16 @@ function setUp() {
   remoteService = TestBed.get(HttpTestingController);
 }
 
+function expectAuthorisedRequest(token: string, httpMethod?: string): TestRequest {
+  const request = remoteService.expectOne(req => req.url.startsWith(environment.INGEST_API_URL));
+  const authorization = request.request.headers.get('Authorization');
+  expect(authorization).toEqual(`Bearer ${token}`);
+  if (httpMethod) {
+    expect(request.request.method).toEqual(httpMethod);
+  }
+  return request;
+};
+
 describe('Get Account', () => {
 
   beforeEach(setUp);
@@ -35,12 +45,10 @@ describe('Get Account', () => {
     });
 
     //given:
-    const request = expectRemoteRequest(token, 'GET');
+    const request = expectAuthorisedRequest(token, 'GET');
     request.flush({
       'id': accountId,
-      'roles': [
-        'CONTRIBUTOR'
-      ],
+      'roles': ['CONTRIBUTOR'],
     });
 
     //and:
@@ -55,22 +63,12 @@ describe('Get Account', () => {
     });
 
     //given:
-    const request = expectRemoteRequest(token, 'GET');
+    const request = expectAuthorisedRequest(token, 'GET');
     request.flush(null, { status: 404, statusText: 'not found' });
 
     //and:
     done();
   });
-
-  function expectRemoteRequest(token: string, httpMethod?: string): TestRequest {
-    const request = remoteService.expectOne(req => req.url.startsWith('http'));
-    const authorization = request.request.headers.get('Authorization');
-    expect(authorization).toEqual(`Bearer ${token}`);
-    if (httpMethod) {
-      expect(request.request.method).toEqual(httpMethod);
-    }
-    return request;
-  };
 
 });
 
@@ -91,10 +89,7 @@ describe('Account Registration', () => {
     });
 
     //given:
-    const request = remoteService.expectOne(req => req.url.startsWith(environment.INGEST_API_URL));
-    expect(request.request.method).toEqual('POST');
-
-    //and:
+    const request = expectAuthorisedRequest(token, 'POST');
     request.flush({
       'id': accountId,
       'providerReference': providerReference,

--- a/client/src/app/core/authentication.service.spec.ts
+++ b/client/src/app/core/authentication.service.spec.ts
@@ -1,6 +1,7 @@
 import {AuthenticationService} from "./authentication.service";
 import {TestBed} from "@angular/core/testing";
 import {HttpClientTestingModule, HttpTestingController, TestRequest} from "@angular/common/http/testing";
+import {environment} from "../../environments/environment";
 
 let accountService: AuthenticationService;
 let remoteService: HttpTestingController
@@ -79,13 +80,30 @@ describe('Account Registration', () => {
 
   it('should return Account data after registration', (done) => {
     //expect:
+    const accountId = '72f9001';
+    const providerReference = '127ee11';
     const token = 'ZW5jb2RlZCBzdHJpbmcK';
     accountService.register(token).subscribe(account => {
       expect(account).toBeTruthy();
+      expect(account.id).toEqual(accountId);
+      expect(account.providerReference).toEqual(providerReference);
+      expect(account.roles).toContain('CONTRIBUTOR');
     });
+
+    //given:
+    const request = remoteService.expectOne(req => req.url.startsWith(environment.INGEST_API_URL));
+    expect(request.request.method).toEqual('POST');
+
+    //and:
+    request.flush({
+      'id': accountId,
+      'providerReference': providerReference,
+      'roles': ['CONTRIBUTOR'],
+    })
 
     //and:
     done();
+    remoteService.verify();
   });
 
 });

--- a/client/src/app/core/authentication.service.spec.ts
+++ b/client/src/app/core/authentication.service.spec.ts
@@ -72,3 +72,20 @@ describe('Get Account', () => {
   };
 
 });
+
+describe('Account Registration', () => {
+
+  beforeEach(setUp);
+
+  it('should return Account data after registration', (done) => {
+    //expect:
+    const token = 'ZW5jb2RlZCBzdHJpbmcK';
+    accountService.register(token).subscribe(account => {
+      expect(account).toBeTruthy();
+    });
+
+    //and:
+    done();
+  });
+
+});

--- a/client/src/app/core/authentication.service.spec.ts
+++ b/client/src/app/core/authentication.service.spec.ts
@@ -2,6 +2,7 @@ import {AuthenticationService, DuplicateAccount} from "./authentication.service"
 import {TestBed} from "@angular/core/testing";
 import {HttpClientTestingModule, HttpTestingController, TestRequest} from "@angular/common/http/testing";
 import {environment} from "../../environments/environment";
+import {Account} from "./security.data";
 
 let accountService: AuthenticationService;
 let remoteService: HttpTestingController
@@ -38,7 +39,7 @@ describe('Get Account', () => {
     //expect:
     const accountId = 'c83bf90';
     const token = 'aGVsbG8sIHdvcmxkCg==';
-    accountService.getAccount(token).then(account => {
+    accountService.getAccount(token).then((account: Account) => {
       expect(account).toBeTruthy();
       expect(account.id).toEqual(accountId);
       expect(account.roles).toContain('CONTRIBUTOR');
@@ -58,8 +59,8 @@ describe('Get Account', () => {
   it('should return empty object if the User is not registered', (done) => {
     //expect:
     const token = 'bWFnaWMgc3RyaW5nCg==';
-    accountService.getAccount(token).then(account => {
-      expect(account).toEqual({});
+    accountService.getAccount(token).then((account: Account) => {
+      expect(account).toEqual(<Account>{});
     });
 
     //given:

--- a/client/src/app/core/authentication.service.spec.ts
+++ b/client/src/app/core/authentication.service.spec.ts
@@ -1,5 +1,5 @@
 import {AuthenticationService, DuplicateAccount} from "./authentication.service";
-import {TestBed} from "@angular/core/testing";
+import {fakeAsync, TestBed} from "@angular/core/testing";
 import {HttpClientTestingModule, HttpTestingController, TestRequest} from "@angular/common/http/testing";
 import {environment} from "../../environments/environment";
 import {Account} from "./security.data";
@@ -35,28 +35,27 @@ describe('Get Account', () => {
     remoteService.verify();
   });
 
-  it('should return an Account if the User is registered', (done) => {
-    //expect:
-    const accountId = 'c83bf90';
-    const token = 'aGVsbG8sIHdvcmxkCg==';
-    accountService.getAccount(token).then((account: Account) => {
-      expect(account).toBeTruthy();
-      expect(account.id).toEqual(accountId);
-      expect(account.roles).toContain('CONTRIBUTOR');
-    });
+  it('should return an Account if the User is registered', fakeAsync(() => {
+    {
+      //expect:
+      const accountId = 'c83bf90';
+      const token = 'aGVsbG8sIHdvcmxkCg==';
+      accountService.getAccount(token).then((account: Account) => {
+        expect(account).toBeTruthy();
+        expect(account.id).toEqual(accountId);
+        expect(account.roles).toContain('CONTRIBUTOR');
+      });
 
-    //given:
-    const request = expectAuthorisedRequest(token, 'GET');
-    request.flush({
-      'id': accountId,
-      'roles': ['CONTRIBUTOR'],
-    });
+      //given:
+      const request = expectAuthorisedRequest(token, 'GET');
+      request.flush({
+        'id': accountId,
+        'roles': ['CONTRIBUTOR'],
+      });
+    }
+  }));
 
-    //and:
-    done();
-  });
-
-  it('should return empty object if the User is not registered', (done) => {
+  it('should return empty object if the User is not registered', fakeAsync(() => {
     //expect:
     const token = 'bWFnaWMgc3RyaW5nCg==';
     accountService.getAccount(token).then((account: Account) => {
@@ -66,10 +65,7 @@ describe('Get Account', () => {
     //given:
     const request = expectAuthorisedRequest(token, 'GET');
     request.flush(null, { status: 404, statusText: 'not found' });
-
-    //and:
-    done();
-  });
+  }));
 
 });
 
@@ -81,7 +77,7 @@ describe('Account Registration', () => {
     remoteService.verify();
   });
 
-  it('should return Account data after registration', (done) => {
+  it('should return Account data after registration', fakeAsync(() => {
     //expect:
     const accountId = '72f9001';
     const providerReference = '127ee11';
@@ -100,28 +96,22 @@ describe('Account Registration', () => {
       providerReference: providerReference,
       roles: ['CONTRIBUTOR'],
     })
+  }));
 
-    //and:
-    done();
-  });
-
-  it('should throw an error when the User is already registered (403)', (done) => {
+  it('should throw an error when the User is already registered (403)', fakeAsync(() => {
     testForError(DuplicateAccount, 403, 'Forbidden');
-    done();
-  });
+  }));
 
-  it('should throw an error when registration results in conflict (409)', (done) => {
+  it('should throw an error when registration results in conflict (409)', fakeAsync(() => {
     testForError(DuplicateAccount, 409, 'conflict');
-    done();
-  });
+  }));
 
-  it('should rethrow any other error', (done) => {
+  it('should rethrow any other error', fakeAsync(() => {
     testForError(Error, 400, 'client error',
       (error) => {
         expect(error.message).toContain('client error');
       });
-    done();
-  });
+  }));
 
   function testForError(errorType, httpStatus: number, statusText?: string | 'error', postCondition?) {
     //expect:

--- a/client/src/app/core/authentication.service.spec.ts
+++ b/client/src/app/core/authentication.service.spec.ts
@@ -2,19 +2,22 @@ import {AuthenticationService} from "./authentication.service";
 import {TestBed} from "@angular/core/testing";
 import {HttpClientTestingModule, HttpTestingController, TestRequest} from "@angular/common/http/testing";
 
+let accountService: AuthenticationService;
+let remoteService: HttpTestingController
+
+function setUp() {
+  TestBed.configureTestingModule({
+    providers: [AuthenticationService],
+    imports: [HttpClientTestingModule],
+  });
+
+  accountService = TestBed.get(AuthenticationService);
+  remoteService = TestBed.get(HttpTestingController);
+}
+
 describe('Get Account', () => {
-  let service: AuthenticationService;
-  let remoteService: HttpTestingController
 
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-      providers: [AuthenticationService],
-      imports: [HttpClientTestingModule],
-    });
-
-    service = TestBed.get(AuthenticationService)
-    remoteService = TestBed.get(HttpTestingController)
-  })
+  beforeEach(setUp);
 
   afterEach(() => {
     remoteService.verify();
@@ -24,7 +27,7 @@ describe('Get Account', () => {
     //expect:
     const accountId = 'c83bf90';
     const token = 'aGVsbG8sIHdvcmxkCg==';
-    service.getAccount(token).subscribe(account => {
+    accountService.getAccount(token).subscribe(account => {
       expect(account).toBeTruthy();
       expect(account.id).toEqual(accountId);
       expect(account.roles).toContain('CONTRIBUTOR');
@@ -46,7 +49,7 @@ describe('Get Account', () => {
   it('should return empty object if the User is not registered', (done) => {
     //expect:
     const token = 'bWFnaWMgc3RyaW5nCg==';
-    service.getAccount(token).subscribe(account => {
+    accountService.getAccount(token).subscribe(account => {
       expect(account).toEqual({});
     });
 
@@ -68,4 +71,4 @@ describe('Get Account', () => {
     return request;
   };
 
-})
+});

--- a/client/src/app/core/authentication.service.spec.ts
+++ b/client/src/app/core/authentication.service.spec.ts
@@ -59,11 +59,9 @@ describe('Get Account', () => {
   });
 
   function expectRemoteRequest(token: string, httpMethod?: string): TestRequest {
-    const request = remoteService.expectOne(req => {
-      let authorization = req.headers.get('Authorization');
-      let hasCorrectAuthorization = authorization && authorization === `Bearer ${token}`;
-      return req.url.startsWith('http') && hasCorrectAuthorization;
-    });
+    const request = remoteService.expectOne(req => req.url.startsWith('http'));
+    const authorization = request.request.headers.get('Authorization');
+    expect(authorization).toEqual(`Bearer ${token}`);
     if (httpMethod) {
       expect(request.request.method).toEqual(httpMethod);
     }

--- a/client/src/app/core/authentication.service.spec.ts
+++ b/client/src/app/core/authentication.service.spec.ts
@@ -86,7 +86,7 @@ describe('Account Registration', () => {
     const accountId = '72f9001';
     const providerReference = '127ee11';
     const token = 'ZW5jb2RlZCBzdHJpbmcK';
-    accountService.register(token).then(account => {
+    accountService.register(token).then((account: Account) => {
       expect(account).toBeTruthy();
       expect(account.id).toEqual(accountId);
       expect(account.providerReference).toEqual(providerReference);
@@ -95,10 +95,10 @@ describe('Account Registration', () => {
 
     //given:
     const request = expectAuthorisedRequest(token, 'POST');
-    request.flush({
-      'id': accountId,
-      'providerReference': providerReference,
-      'roles': ['CONTRIBUTOR'],
+    request.flush(<Account>{
+      id: accountId,
+      providerReference: providerReference,
+      roles: ['CONTRIBUTOR'],
     })
 
     //and:

--- a/client/src/app/core/authentication.service.spec.ts
+++ b/client/src/app/core/authentication.service.spec.ts
@@ -16,14 +16,15 @@ describe('Get Account', () => {
     remoteService = TestBed.get(HttpTestingController)
   })
 
-  it('should return an Account', (done) => {
+  it('should return an Account if the User is registered', (done) => {
     //expect:
     let accountId = 'c83bf90';
     let token = 'aGVsbG8sIHdvcmxkCg==';
     service.getAccount(token).subscribe(account => {
       expect(account).toBeTruthy();
       expect(account.id).toEqual(accountId);
-    })
+      expect(account.roles).toContain('CONTRIBUTOR');
+    });
 
     //given:
     const request = remoteService.expectOne(req => {
@@ -36,6 +37,9 @@ describe('Get Account', () => {
     and:
     request.flush({
       'id': accountId,
+      'roles': [
+        'CONTRIBUTOR'
+      ],
     });
 
     //and:

--- a/client/src/app/core/authentication.service.spec.ts
+++ b/client/src/app/core/authentication.service.spec.ts
@@ -35,7 +35,7 @@ describe('Get Account', () => {
     remoteService.verify();
   });
 
-  it('should return an Account if the User is registered', fakeAsync(() => {
+  it('should resolve to an Account if the User is registered', fakeAsync(() => {
     {
       //expect:
       const accountId = 'c83bf90';
@@ -55,12 +55,16 @@ describe('Get Account', () => {
     }
   }));
 
-  it('should return empty object if the User is not registered', fakeAsync(() => {
+  it('should reject with an empty Account if the User is not registered', fakeAsync(() => {
     //expect:
     const token = 'bWFnaWMgc3RyaW5nCg==';
-    accountService.getAccount(token).then((account: Account) => {
-      expect(account).toEqual(<Account>{});
-    });
+    accountService.getAccount(token)
+      .then(() => {
+        fail('service is expected to reject for unregistered User');
+      })
+      .catch((account: Account) => {
+        expect(account).toEqual(<Account>{});
+      });
 
     //given:
     const request = expectAuthorisedRequest(token, 'GET');

--- a/client/src/app/core/authentication.service.spec.ts
+++ b/client/src/app/core/authentication.service.spec.ts
@@ -39,7 +39,7 @@ describe('Get Account', () => {
     //expect:
     const accountId = 'c83bf90';
     const token = 'aGVsbG8sIHdvcmxkCg==';
-    accountService.getAccount(token).subscribe(account => {
+    accountService.getAccount(token).then(account => {
       expect(account).toBeTruthy();
       expect(account.id).toEqual(accountId);
       expect(account.roles).toContain('CONTRIBUTOR');
@@ -59,7 +59,7 @@ describe('Get Account', () => {
   it('should return empty object if the User is not registered', (done) => {
     //expect:
     const token = 'bWFnaWMgc3RyaW5nCg==';
-    accountService.getAccount(token).subscribe(account => {
+    accountService.getAccount(token).then(account => {
       expect(account).toEqual({});
     });
 

--- a/client/src/app/core/authentication.service.spec.ts
+++ b/client/src/app/core/authentication.service.spec.ts
@@ -1,4 +1,4 @@
-import {AuthenticationService} from "./authentication.service";
+import {AuthenticationService, DuplicateAccount} from "./authentication.service";
 import {TestBed} from "@angular/core/testing";
 import {HttpClientTestingModule, HttpTestingController, TestRequest} from "@angular/common/http/testing";
 import {environment} from "../../environments/environment";
@@ -76,6 +76,10 @@ describe('Account Registration', () => {
 
   beforeEach(setUp);
 
+  afterEach(() => {
+    remoteService.verify();
+  });
+
   it('should return Account data after registration', (done) => {
     //expect:
     const accountId = '72f9001';
@@ -98,7 +102,26 @@ describe('Account Registration', () => {
 
     //and:
     done();
-    remoteService.verify();
+  });
+
+  it('should throw an error when the User is already registered (403)', (done) => {
+    //expect:
+    const token = 'dG9rZW4K';
+    accountService.register(token).subscribe(
+      (success) => {
+        fail('Registration is expected to throw an error.');
+      },
+      (error) => {
+        expect(error).toEqual(jasmine.any(DuplicateAccount));
+      }
+    );
+
+    //given:
+    const request = expectAuthorisedRequest(token, 'POST');
+    request.flush(null, { status: 403, statusText: 'forbidden' });
+
+    //and:
+    done();
   });
 
 });

--- a/client/src/app/core/authentication.service.spec.ts
+++ b/client/src/app/core/authentication.service.spec.ts
@@ -105,6 +105,11 @@ describe('Account Registration', () => {
   });
 
   it('should throw an error when the User is already registered (403)', (done) => {
+    testForError(DuplicateAccount, 403, 'Forbidden');
+    done();
+  });
+
+  function testForError(errorType, httpStatus: number, statusText?: string | 'error') {
     //expect:
     const token = 'dG9rZW4K';
     accountService.register(token).subscribe(
@@ -112,16 +117,13 @@ describe('Account Registration', () => {
         fail('Registration is expected to throw an error.');
       },
       (error) => {
-        expect(error).toEqual(jasmine.any(DuplicateAccount));
+        expect(error).toEqual(jasmine.any(errorType));
       }
     );
 
     //given:
     const request = expectAuthorisedRequest(token, 'POST');
-    request.flush(null, { status: 403, statusText: 'forbidden' });
-
-    //and:
-    done();
-  });
+    request.flush(null, { status: httpStatus, statusText: statusText });
+  }
 
 });

--- a/client/src/app/core/authentication.service.spec.ts
+++ b/client/src/app/core/authentication.service.spec.ts
@@ -19,13 +19,18 @@ describe('Get Account', () => {
   it('should return an Account', (done) => {
     //expect:
     let accountId = 'c83bf90';
-    service.getAccount().subscribe(account => {
+    let token = 'aGVsbG8sIHdvcmxkCg==';
+    service.getAccount(token).subscribe(account => {
       expect(account).toBeTruthy();
       expect(account.id).toEqual(accountId);
     })
 
     //given:
-    const request = remoteService.expectOne('/test');
+    const request = remoteService.expectOne(req => {
+      let authorization = req.headers.get('Authorization');
+      let hasCorrectAuthorization = authorization && authorization === `Bearer ${token}`;
+      return req.url.startsWith('http') && hasCorrectAuthorization;
+    });
     expect(request.request.method).toEqual('GET');
 
     and:

--- a/client/src/app/core/authentication.service.spec.ts
+++ b/client/src/app/core/authentication.service.spec.ts
@@ -1,0 +1,40 @@
+import {AuthenticationService} from "./authentication.service";
+import {TestBed} from "@angular/core/testing";
+import {HttpClientTestingModule, HttpTestingController} from "@angular/common/http/testing";
+
+describe('Get Account', () => {
+  let service: AuthenticationService;
+  let remoteService: HttpTestingController
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [AuthenticationService],
+      imports: [HttpClientTestingModule],
+    });
+
+    service = TestBed.get(AuthenticationService)
+    remoteService = TestBed.get(HttpTestingController)
+  })
+
+  it('should return an Account', (done) => {
+    //expect:
+    let accountId = 'c83bf90';
+    service.getAccount().subscribe(account => {
+      expect(account).toBeTruthy();
+      expect(account.id).toEqual(accountId);
+    })
+
+    //given:
+    const request = remoteService.expectOne('/test');
+    expect(request.request.method).toEqual('GET');
+
+    and:
+    request.flush({
+      'id': accountId,
+    });
+
+    //and:
+    remoteService.verify();
+    done();
+  });
+})

--- a/client/src/app/core/authentication.service.spec.ts
+++ b/client/src/app/core/authentication.service.spec.ts
@@ -1,4 +1,4 @@
-import {AuthenticationService, DuplicateAccount} from "./authentication.service";
+import {AuthenticationService, RegistrationErrorCode, RegistrationFailed} from "./authentication.service";
 import {fakeAsync, TestBed} from "@angular/core/testing";
 import {HttpClientTestingModule, HttpTestingController, TestRequest} from "@angular/common/http/testing";
 import {environment} from "../../environments/environment";
@@ -103,29 +103,29 @@ describe('Account Registration', () => {
   }));
 
   it('should throw an error when the User is already registered (403)', fakeAsync(() => {
-    testForError(DuplicateAccount, 403, 'Forbidden');
+    testForError(RegistrationErrorCode.Duplication, 403, 'Forbidden');
   }));
 
   it('should throw an error when registration results in conflict (409)', fakeAsync(() => {
-    testForError(DuplicateAccount, 409, 'conflict');
+    testForError(RegistrationErrorCode.Duplication, 409, 'conflict');
   }));
 
   it('should rethrow any other error', fakeAsync(() => {
-    testForError(Error, 400, 'client error',
+    testForError(RegistrationErrorCode.ServiceError, 400, 'client error',
       (error) => {
         expect(error.message).toContain('client error');
       });
   }));
 
-  function testForError(errorType, httpStatus: number, statusText?: string | 'error', postCondition?) {
+  function testForError(errorCode, httpStatus: number, statusText?: string | 'error', postCondition?) {
     //expect:
     const token = 'dG9rZW4K';
     accountService.register(token)
       .then(() => {
         fail('Registration is expected to throw an error.');
       })
-      .catch((error) => {
-        expect(error).toEqual(jasmine.any(errorType));
+      .catch((error: RegistrationFailed) => {
+        expect(error.errorCode).toEqual(errorCode);
         if (postCondition) {
           postCondition(error);
         }

--- a/client/src/app/core/authentication.service.spec.ts
+++ b/client/src/app/core/authentication.service.spec.ts
@@ -2,7 +2,6 @@ import {AuthenticationService, DuplicateAccount} from "./authentication.service"
 import {TestBed} from "@angular/core/testing";
 import {HttpClientTestingModule, HttpTestingController, TestRequest} from "@angular/common/http/testing";
 import {environment} from "../../environments/environment";
-import {HttpErrorResponse} from "@angular/common/http";
 
 let accountService: AuthenticationService;
 let remoteService: HttpTestingController
@@ -86,7 +85,7 @@ describe('Account Registration', () => {
     const accountId = '72f9001';
     const providerReference = '127ee11';
     const token = 'ZW5jb2RlZCBzdHJpbmcK';
-    accountService.register(token).subscribe(account => {
+    accountService.register(token).then(account => {
       expect(account).toBeTruthy();
       expect(account.id).toEqual(accountId);
       expect(account.providerReference).toEqual(providerReference);
@@ -126,25 +125,20 @@ describe('Account Registration', () => {
   function testForError(errorType, httpStatus: number, statusText?: string | 'error', postCondition?) {
     //expect:
     const token = 'dG9rZW4K';
-    let sourceError;
-    accountService.register(token).subscribe(
-      (success) => {
+    accountService.register(token)
+      .then(() => {
         fail('Registration is expected to throw an error.');
-      },
-      (error) => {
+      })
+      .catch((error) => {
         expect(error).toEqual(jasmine.any(errorType));
-        sourceError = error;
-      }
-    );
+        if (postCondition) {
+          postCondition(error);
+        }
+      });
 
     //given:
     const request = expectAuthorisedRequest(token, 'POST');
     request.flush(null, { status: httpStatus, statusText: statusText });
-
-    //and:
-    if (postCondition) {
-      postCondition(sourceError);
-    }
   }
 
 });

--- a/client/src/app/core/authentication.service.ts
+++ b/client/src/app/core/authentication.service.ts
@@ -1,6 +1,7 @@
 import {Observable} from "rxjs";
 import {HttpClient} from "@angular/common/http";
 import {Injectable} from "@angular/core";
+import {environment} from "../../environments/environment";
 
 @Injectable({
   providedIn: 'root'
@@ -9,8 +10,12 @@ export class AuthenticationService {
 
   constructor(private http: HttpClient) {}
 
-  getAccount(): Observable<any> {
-    return this.http.get('/test');
+  getAccount(token: string): Observable<any> {
+    let url = `${environment.INGEST_API_URL}/auth/account`;
+    let headers = {
+      Authorization: `Bearer ${token}`,
+    };
+    return this.http.get(url, { headers: headers });
   }
 
 }

--- a/client/src/app/core/authentication.service.ts
+++ b/client/src/app/core/authentication.service.ts
@@ -2,9 +2,10 @@ import {Observable} from "rxjs";
 import {HttpClient, HttpErrorResponse} from "@angular/common/http";
 import {Injectable} from "@angular/core";
 import {environment} from "../../environments/environment";
+import {CoreSecurity} from "./security.module";
 
 @Injectable({
-  providedIn: 'root'
+  providedIn: CoreSecurity,
 })
 export class AuthenticationService {
 

--- a/client/src/app/core/authentication.service.ts
+++ b/client/src/app/core/authentication.service.ts
@@ -26,7 +26,11 @@ export class AuthenticationService {
     return this.http
       .post(url, {}, {headers: this.authoriseHeader(token)})
       .catch((error: HttpErrorResponse) => {
-        return Observable.throwError(new DuplicateAccount());
+        let serviceError = new Error(error.message);
+        if ([403, 409].includes(error.status)) {
+          serviceError = new DuplicateAccount();
+        }
+        return Observable.throwError(serviceError);
       });
   }
 

--- a/client/src/app/core/authentication.service.ts
+++ b/client/src/app/core/authentication.service.ts
@@ -11,19 +11,20 @@ export class AuthenticationService {
 
   constructor(private http: HttpClient) {}
 
+  private readonly URL = `${environment.INGEST_API_URL}/auth/account`;
+
   getAccount(token: string): Observable<any> {
-    const url = `${environment.INGEST_API_URL}/auth/account`;
     const headers = {
       Authorization: `Bearer ${token}`,
     };
     return this.http
-      .get(url, {headers: headers})
+      .get(this.URL, {headers: headers})
       .catch((error: HttpErrorResponse) => {
         return Observable.of({});
       });
   }
 
   register(token: string): Observable<any> {
-    return Observable.of({});
+    return this.http.post(this.URL, {});
   }
 }

--- a/client/src/app/core/authentication.service.ts
+++ b/client/src/app/core/authentication.service.ts
@@ -10,18 +10,24 @@ export class AuthenticationService {
 
   constructor(private http: HttpClient) {}
 
-  private readonly URL = `${environment.INGEST_API_URL}/auth/account`;
+  private readonly BASE_URL = `${environment.INGEST_API_URL}/auth`;
 
   getAccount(token: string): Observable<any> {
+    const url = `${this.BASE_URL}/account`;
     return this.http
-      .get(this.URL, {headers: this.authoriseHeader(token)})
+      .get(url, {headers: this.authoriseHeader(token)})
       .catch((error: HttpErrorResponse) => {
         return Observable.of({});
       });
   }
 
   register(token: string): Observable<any> {
-    return this.http.post(this.URL, {}, {headers: this.authoriseHeader(token)});
+    const url = `${this.BASE_URL}/registration`;
+    return this.http
+      .post(url, {}, {headers: this.authoriseHeader(token)})
+      .catch((error: HttpErrorResponse) => {
+        return Observable.throwError(new DuplicateAccount());
+      });
   }
 
   private authoriseHeader(token: string) {
@@ -29,5 +35,12 @@ export class AuthenticationService {
       Authorization: `Bearer ${token}`,
     };
   }
+
+}
+
+export class DuplicateAccount implements Error {
+
+  readonly name: string = 'DuplicateAccount';
+  readonly message: string = 'Operation failed due to duplicate Accounts.';
 
 }

--- a/client/src/app/core/authentication.service.ts
+++ b/client/src/app/core/authentication.service.ts
@@ -12,13 +12,13 @@ export class AuthenticationService {
 
   private readonly BASE_URL = `${environment.INGEST_API_URL}/auth`;
 
-  getAccount(token: string): Observable<any> {
+  getAccount(token: string): Promise<any> {
     const url = `${this.BASE_URL}/account`;
     return this.http
       .get(url, {headers: this.authoriseHeader(token)})
       .catch((error: HttpErrorResponse) => {
         return Observable.of({});
-      });
+      }).toPromise();
   }
 
   register(token: string): Observable<any> {

--- a/client/src/app/core/authentication.service.ts
+++ b/client/src/app/core/authentication.service.ts
@@ -23,4 +23,7 @@ export class AuthenticationService {
       });
   }
 
+  register(token: string): Observable<any> {
+    return Observable.of({});
+  }
 }

--- a/client/src/app/core/authentication.service.ts
+++ b/client/src/app/core/authentication.service.ts
@@ -1,7 +1,8 @@
 import {Observable} from "rxjs";
-import {HttpClient} from "@angular/common/http";
+import {HttpClient, HttpErrorResponse} from "@angular/common/http";
 import {Injectable} from "@angular/core";
 import {environment} from "../../environments/environment";
+import {catchError} from "rxjs/operators";
 
 @Injectable({
   providedIn: 'root'
@@ -11,11 +12,15 @@ export class AuthenticationService {
   constructor(private http: HttpClient) {}
 
   getAccount(token: string): Observable<any> {
-    let url = `${environment.INGEST_API_URL}/auth/account`;
-    let headers = {
+    const url = `${environment.INGEST_API_URL}/auth/account`;
+    const headers = {
       Authorization: `Bearer ${token}`,
     };
-    return this.http.get(url, { headers: headers });
+    return this.http
+      .get(url, {headers: headers})
+      .catch((error: HttpErrorResponse) => {
+        return Observable.of({});
+      });
   }
 
 }

--- a/client/src/app/core/authentication.service.ts
+++ b/client/src/app/core/authentication.service.ts
@@ -1,0 +1,16 @@
+import {Observable} from "rxjs";
+import {HttpClient} from "@angular/common/http";
+import {Injectable} from "@angular/core";
+
+@Injectable({
+  providedIn: 'root'
+})
+export class AuthenticationService {
+
+  constructor(private http: HttpClient) {}
+
+  getAccount(): Observable<any> {
+    return this.http.get('/test');
+  }
+
+}

--- a/client/src/app/core/authentication.service.ts
+++ b/client/src/app/core/authentication.service.ts
@@ -28,9 +28,12 @@ export class AuthenticationService {
     return this.http
       .post<Account>(url, {}, {headers: this.authoriseHeader(token)})
       .catch((error: HttpErrorResponse) => {
-        let serviceError = new Error(error.message);
+        const serviceError = <RegistrationFailed>{};
         if ([403, 409].includes(error.status)) {
-          serviceError = new DuplicateAccount();
+          serviceError.errorCode = RegistrationErrorCode.Duplication;
+        } else {
+          serviceError.errorCode = RegistrationErrorCode.ServiceError;
+          serviceError.message = error.message;
         }
         return Observable.throwError(serviceError);
       }).toPromise();
@@ -44,9 +47,16 @@ export class AuthenticationService {
 
 }
 
-export class DuplicateAccount implements Error {
+export enum RegistrationErrorCode {
+  Duplication = 'registration.error.duplicateAccounts',
+  ServiceError = 'registration.error.serviceError',
+  Unknown = 'registration.error.unknown'
+}
 
-  readonly name: string = 'DuplicateAccount';
-  readonly message: string = 'Operation failed due to duplicate Accounts.';
+export class RegistrationFailed implements Error {
+
+  name: string = 'RegistrationFailed';
+  message: string = 'Account registration failed';
+  errorCode: RegistrationErrorCode = RegistrationErrorCode.Unknown;
 
 }

--- a/client/src/app/core/authentication.service.ts
+++ b/client/src/app/core/authentication.service.ts
@@ -2,7 +2,6 @@ import {Observable} from "rxjs";
 import {HttpClient, HttpErrorResponse} from "@angular/common/http";
 import {Injectable} from "@angular/core";
 import {environment} from "../../environments/environment";
-import {catchError} from "rxjs/operators";
 
 @Injectable({
   providedIn: 'root'
@@ -14,17 +13,21 @@ export class AuthenticationService {
   private readonly URL = `${environment.INGEST_API_URL}/auth/account`;
 
   getAccount(token: string): Observable<any> {
-    const headers = {
-      Authorization: `Bearer ${token}`,
-    };
     return this.http
-      .get(this.URL, {headers: headers})
+      .get(this.URL, {headers: this.authoriseHeader(token)})
       .catch((error: HttpErrorResponse) => {
         return Observable.of({});
       });
   }
 
   register(token: string): Observable<any> {
-    return this.http.post(this.URL, {});
+    return this.http.post(this.URL, {}, {headers: this.authoriseHeader(token)});
   }
+
+  private authoriseHeader(token: string) {
+    return {
+      Authorization: `Bearer ${token}`,
+    };
+  }
+
 }

--- a/client/src/app/core/authentication.service.ts
+++ b/client/src/app/core/authentication.service.ts
@@ -3,6 +3,7 @@ import {HttpClient, HttpErrorResponse} from "@angular/common/http";
 import {Injectable} from "@angular/core";
 import {environment} from "../../environments/environment";
 import {CoreSecurity} from "./security.module";
+import {Account} from "./security.data";
 
 @Injectable({
   providedIn: CoreSecurity,
@@ -13,12 +14,12 @@ export class AuthenticationService {
 
   private readonly BASE_URL = `${environment.INGEST_API_URL}/auth`;
 
-  getAccount(token: string): Promise<any> {
+  getAccount(token: string): Promise<Account> {
     const url = `${this.BASE_URL}/account`;
     return this.http
-      .get(url, {headers: this.authoriseHeader(token)})
+      .get<Account>(url, {headers: this.authoriseHeader(token)})
       .catch((error: HttpErrorResponse) => {
-        return Observable.of({});
+        return Observable.of(<Account>{});
       }).toPromise();
   }
 

--- a/client/src/app/core/authentication.service.ts
+++ b/client/src/app/core/authentication.service.ts
@@ -23,10 +23,10 @@ export class AuthenticationService {
       }).toPromise();
   }
 
-  register(token: string): Promise<any> {
+  register(token: string): Promise<Account> {
     const url = `${this.BASE_URL}/registration`;
     return this.http
-      .post(url, {}, {headers: this.authoriseHeader(token)})
+      .post<Account>(url, {}, {headers: this.authoriseHeader(token)})
       .catch((error: HttpErrorResponse) => {
         let serviceError = new Error(error.message);
         if ([403, 409].includes(error.status)) {

--- a/client/src/app/core/authentication.service.ts
+++ b/client/src/app/core/authentication.service.ts
@@ -19,7 +19,7 @@ export class AuthenticationService {
     return this.http
       .get<Account>(url, {headers: this.authoriseHeader(token)})
       .catch((error: HttpErrorResponse) => {
-        return Observable.of(<Account>{});
+        return Observable.throwError(<Account>{});
       }).toPromise();
   }
 

--- a/client/src/app/core/authentication.service.ts
+++ b/client/src/app/core/authentication.service.ts
@@ -21,7 +21,7 @@ export class AuthenticationService {
       }).toPromise();
   }
 
-  register(token: string): Observable<any> {
+  register(token: string): Promise<any> {
     const url = `${this.BASE_URL}/registration`;
     return this.http
       .post(url, {}, {headers: this.authoriseHeader(token)})
@@ -31,7 +31,7 @@ export class AuthenticationService {
           serviceError = new DuplicateAccount();
         }
         return Observable.throwError(serviceError);
-      });
+      }).toPromise();
   }
 
   private authoriseHeader(token: string) {

--- a/client/src/app/core/security.data.ts
+++ b/client/src/app/core/security.data.ts
@@ -1,0 +1,5 @@
+export interface Account {
+  id: string;
+  providerReference: string;
+  roles: string[];
+}

--- a/client/src/app/core/security.module.ts
+++ b/client/src/app/core/security.module.ts
@@ -1,0 +1,4 @@
+import {NgModule} from "@angular/core";
+
+@NgModule()
+export class CoreSecurity {}

--- a/client/src/app/login/login.component.spec.ts
+++ b/client/src/app/login/login.component.spec.ts
@@ -14,7 +14,6 @@ describe('LoginComponent', () => {
   let component: LoginComponent;
   let mockAaiSvc, mockRouterSvc, mockAlertSvc;
   let isAuthenticatedSpy: jasmine.Spy;
-  let getUserSpy: jasmine.Spy;
 
   beforeEach(() => {
     mockAaiSvc = jasmine.createSpyObj(['getUser', 'isUserLoggedIn', 'isUserLoggedInAndFromEBI', 'startAuthentication']);
@@ -41,7 +40,7 @@ describe('LoginComponent', () => {
     it('should redirect and authorise the user', () => {
       mockAaiSvc.isUserLoggedInAndFromEBI.and.returnValue(of(false));
       isAuthenticatedSpy = mockAaiSvc.isUserLoggedIn.and.returnValue(of(false));
-      getUserSpy = mockAaiSvc.getUser.and.returnValue(of(<User>{expired: false}));
+      mockAaiSvc.getUser.and.returnValue(of(<User>{expired: false}));
 
       component = new LoginComponent(mockAaiSvc, mockRouterSvc, mockAlertSvc);
       component.login();

--- a/client/src/app/registration/registration.component.css
+++ b/client/src/app/registration/registration.component.css
@@ -1,0 +1,17 @@
+#registration-content {
+  width: 800px;
+  margin: 5px auto;
+  text-align: center;
+}
+
+.message-box {
+  border: 1px solid #999;
+  border-radius: 10px;
+  width: 335px;
+  margin: 5px auto;
+  padding: 15px;
+}
+
+.registration-message {
+  color: #999;
+}

--- a/client/src/app/registration/registration.component.html
+++ b/client/src/app/registration/registration.component.html
@@ -1,0 +1,1 @@
+<p>registration works!</p>

--- a/client/src/app/registration/registration.component.html
+++ b/client/src/app/registration/registration.component.html
@@ -10,6 +10,6 @@
 
   <div *ngIf="status" id="registration-message">
     <p>{{status.message}}</p>
-    <input *ngIf="status.success" type="button" name="ok" value="OK" />
+    <input *ngIf="status.success" type="button" name="ok" value="OK" (click)="router.navigate(['/home'])"/>
   </div>
 </div>

--- a/client/src/app/registration/registration.component.html
+++ b/client/src/app/registration/registration.component.html
@@ -7,4 +7,9 @@
   </span>
 
   <input type="button" name="register" value="Register" [disabled]="!termsAccepted" (click)="proceed()">
+
+  <div *ngIf="status" id="registration-message">
+    <p>{{status.message}}</p>
+    <input *ngIf="status.success" type="button" name="ok" value="OK" />
+  </div>
 </div>

--- a/client/src/app/registration/registration.component.html
+++ b/client/src/app/registration/registration.component.html
@@ -1,15 +1,23 @@
 <div id="registration-content">
   <h1>Welcome to the Human Cell Atlas</h1>
 
+  <p>&nbsp;</p>
   <span id="registration-terms">
-    <input type="checkbox" name="termsAccepted" [(ngModel)]="termsAccepted" />
+    <input type="checkbox" name="termsAccepted" [(ngModel)]="termsAccepted"/>
     &nbsp; By ticking this box, you agree to the terms and condition.
   </span>
 
+  <p>&nbsp;</p>
   <input type="button" name="register" value="Register" [disabled]="!termsAccepted" (click)="proceed()">
 
-  <div *ngIf="status" id="registration-message">
-    <p>{{status.message}}</p>
-    <input *ngIf="status.success" type="button" name="ok" value="OK" (click)="router.navigate(['/home'])"/>
+  <div *ngIf="status && status.message" id="registration-message">
+    <p>&nbsp;</p>
+    <div class="message-box">
+      <span class="registration-message">{{status.message}}</span><br/>
+      <div *ngIf="status.success">
+        <span>&nbsp;</span><br/>
+        <input type="button" name="ok" value="OK" (click)="router.navigate(['/home'])"/>
+      </div>
+    </div>
   </div>
 </div>

--- a/client/src/app/registration/registration.component.html
+++ b/client/src/app/registration/registration.component.html
@@ -1,1 +1,10 @@
-<p>registration works!</p>
+<div id="registration-content">
+  <h1>Welcome to the Human Cell Atlas</h1>
+
+  <span id="registration-terms">
+    <input type="checkbox" name="termsAccepted" [(ngModel)]="termsAccepted" />
+    &nbsp; By ticking this box, you agree to the terms and condition.
+  </span>
+
+  <input type="button" name="register" value="Register" [disabled]="!termsAccepted" (click)="proceed()">
+</div>

--- a/client/src/app/registration/registration.component.spec.ts
+++ b/client/src/app/registration/registration.component.spec.ts
@@ -1,0 +1,25 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { RegistrationComponent } from './registration.component';
+
+describe('RegistrationComponent', () => {
+  let component: RegistrationComponent;
+  let fixture: ComponentFixture<RegistrationComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ RegistrationComponent ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(RegistrationComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/client/src/app/registration/registration.component.spec.ts
+++ b/client/src/app/registration/registration.component.spec.ts
@@ -66,7 +66,8 @@ describe('Registration', () => {
     registration.termsAccepted = true;
 
     //and:
-    const accountPromise = Promise.reject(new DuplicateAccount());
+    const error = new DuplicateAccount();
+    const accountPromise = Promise.reject(error);
     authenticationService.register.and.returnValue(accountPromise);
 
     //when:
@@ -76,6 +77,7 @@ describe('Registration', () => {
     flushMicrotasks();
     expect(authenticationService.register).toHaveBeenCalledWith(accessToken);
     expect(registration.status.success).toEqual(false);
+    expect(registration.status.message).toEqual(error.message);
   }));
 
   it('should NOT proceed if terms are not accepted', async(() => {

--- a/client/src/app/registration/registration.component.spec.ts
+++ b/client/src/app/registration/registration.component.spec.ts
@@ -1,25 +1,34 @@
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import {async, ComponentFixture, TestBed} from '@angular/core/testing';
 
-import { RegistrationComponent } from './registration.component';
+import {RegistrationComponent} from './registration.component';
+import {By} from "@angular/platform-browser";
 
-describe('RegistrationComponent', () => {
-  let component: RegistrationComponent;
-  let fixture: ComponentFixture<RegistrationComponent>;
+let component: RegistrationComponent;
+let fixture: ComponentFixture<RegistrationComponent>;
 
-  beforeEach(async(() => {
-    TestBed.configureTestingModule({
-      declarations: [ RegistrationComponent ]
-    })
-    .compileComponents();
-  }));
+function configureTestEnvironment(): void {
+  TestBed.configureTestingModule({
+    declarations: [ RegistrationComponent ]
+  }).compileComponents();
+}
 
-  beforeEach(() => {
-    fixture = TestBed.createComponent(RegistrationComponent);
-    component = fixture.componentInstance;
-    fixture.detectChanges();
-  });
+function setUp(): void {
+  fixture = TestBed.createComponent(RegistrationComponent);
+  component = fixture.componentInstance;
+  fixture.detectChanges();
+}
 
-  it('should create', () => {
-    expect(component).toBeTruthy();
+describe('Accept Terms', () => {
+  beforeEach(async(configureTestEnvironment));
+  beforeEach(setUp);
+
+  it('can be toggled', () => {
+    expect(component.termsAccepted).toBeFalsy();
+
+    component.acceptTerms();
+    expect(component.termsAccepted).toBeTruthy();
+
+    component.acceptTerms();
+    expect(component.termsAccepted).toBeFalsy();
   });
 });

--- a/client/src/app/registration/registration.component.spec.ts
+++ b/client/src/app/registration/registration.component.spec.ts
@@ -1,20 +1,35 @@
 import {async, ComponentFixture, TestBed} from '@angular/core/testing';
 
 import {RegistrationComponent} from './registration.component';
-import {By} from "@angular/platform-browser";
+import {AuthenticationService} from "../core/authentication.service";
+import {AaiService} from "../aai/aai.service";
+import {User} from "oidc-client";
+import {Observable} from "rxjs";
+import SpyObj = jasmine.SpyObj;
+import createSpyObj = jasmine.createSpyObj;
 
-let component: RegistrationComponent;
+let registration: RegistrationComponent;
 let fixture: ComponentFixture<RegistrationComponent>;
 
+let authenticationService: SpyObj<AuthenticationService>;
+let aaiService: SpyObj<AaiService>;
+
 function configureTestEnvironment(): void {
+  authenticationService = createSpyObj('AuthenticationService', ['register']);
+  aaiService = createSpyObj('AaiService', ['getUser']);
+
   TestBed.configureTestingModule({
-    declarations: [ RegistrationComponent ]
-  }).compileComponents();
+    declarations: [RegistrationComponent],
+    providers: [
+      {provide: AuthenticationService, useFactory: () => authenticationService},
+      {provide: AaiService, useFactory: () => aaiService},
+    ]
+  })
 }
 
 function setUp(): void {
   fixture = TestBed.createComponent(RegistrationComponent);
-  component = fixture.componentInstance;
+  registration = fixture.componentInstance;
   fixture.detectChanges();
 }
 
@@ -23,12 +38,44 @@ describe('Accept Terms', () => {
   beforeEach(setUp);
 
   it('can be toggled', () => {
-    expect(component.termsAccepted).toBeFalsy();
+    expect(registration.termsAccepted).toBeFalsy();
 
-    component.acceptTerms();
-    expect(component.termsAccepted).toBeTruthy();
+    registration.acceptTerms();
+    expect(registration.termsAccepted).toBeTruthy();
 
-    component.acceptTerms();
-    expect(component.termsAccepted).toBeFalsy();
+    registration.acceptTerms();
+    expect(registration.termsAccepted).toBeFalsy();
   });
+});
+
+describe('Registration', () => {
+  beforeEach(async(configureTestEnvironment));
+  beforeEach(setUp);
+
+  const accessToken = '78dea90';
+  const user: User = <User>{access_token: accessToken};
+
+  it('should register through the service if terms are accepted', async(() => {
+    //given:
+    aaiService.getUser.and.returnValue(Observable.of(user));
+    registration.termsAccepted = true;
+
+    //when:
+    registration.proceed();
+
+    //then:
+    expect(authenticationService.register).toHaveBeenCalledWith(accessToken);
+  }));
+
+  it('should NOT proceed if terms are not accepted', async(() => {
+    //given:
+    aaiService.getUser.and.returnValue(Observable.of(user));
+    registration.termsAccepted = false;
+
+    //when:
+    registration.proceed();
+
+    //then:
+    expect(authenticationService.register).not.toHaveBeenCalled();
+  }));
 });

--- a/client/src/app/registration/registration.component.spec.ts
+++ b/client/src/app/registration/registration.component.spec.ts
@@ -60,6 +60,7 @@ describe('Registration', () => {
     flushMicrotasks();
     expect(authenticationService.register).toHaveBeenCalledWith(accessToken);
     expect(registration.status.success).toEqual(true);
+    expect(registration.status.message).not.toBe(undefined);
   }));
 
   it('should set status when registration fails with account duplication', fakeAsync(() => {
@@ -79,7 +80,7 @@ describe('Registration', () => {
     flushMicrotasks();
     expect(authenticationService.register).toHaveBeenCalledWith(accessToken);
     expect(registration.status.success).toEqual(false);
-    expect(registration.status.errorCode).toEqual(failure.errorCode);
+    expect(registration.status.message).not.toBe(undefined);
   }));
 
   it('should NOT proceed if terms are not accepted', async(() => {

--- a/client/src/app/registration/registration.component.spec.ts
+++ b/client/src/app/registration/registration.component.spec.ts
@@ -33,21 +33,6 @@ function setUp(): void {
   fixture.detectChanges();
 }
 
-describe('Accept Terms', () => {
-  beforeEach(async(configureTestEnvironment));
-  beforeEach(setUp);
-
-  it('can be toggled', () => {
-    expect(registration.termsAccepted).toBeFalsy();
-
-    registration.acceptTerms();
-    expect(registration.termsAccepted).toBeTruthy();
-
-    registration.acceptTerms();
-    expect(registration.termsAccepted).toBeFalsy();
-  });
-});
-
 describe('Registration', () => {
   beforeEach(async(configureTestEnvironment));
   beforeEach(setUp);

--- a/client/src/app/registration/registration.component.spec.ts
+++ b/client/src/app/registration/registration.component.spec.ts
@@ -1,11 +1,12 @@
 import {async, ComponentFixture, fakeAsync, flushMicrotasks, TestBed} from '@angular/core/testing';
 
 import {RegistrationComponent} from './registration.component';
-import {AuthenticationService, DuplicateAccount} from "../core/authentication.service";
+import {AuthenticationService, RegistrationErrorCode, RegistrationFailed} from "../core/authentication.service";
 import {AaiService} from "../aai/aai.service";
 import {User} from "oidc-client";
 import {Observable} from "rxjs";
 import {Account} from "../core/security.data";
+import {FormsModule} from "@angular/forms";
 import SpyObj = jasmine.SpyObj;
 import createSpyObj = jasmine.createSpyObj;
 
@@ -21,6 +22,7 @@ function configureTestEnvironment(): void {
 
   TestBed.configureTestingModule({
     declarations: [RegistrationComponent],
+    imports: [FormsModule],
     providers: [
       {provide: AuthenticationService, useFactory: () => authenticationService},
       {provide: AaiService, useFactory: () => aaiService}
@@ -66,7 +68,7 @@ describe('Registration', () => {
     registration.termsAccepted = true;
 
     //and:
-    const error = new DuplicateAccount();
+    const error = <RegistrationFailed>{errorCode: RegistrationErrorCode.Duplication}
     const accountPromise = Promise.reject(error);
     authenticationService.register.and.returnValue(accountPromise);
 

--- a/client/src/app/registration/registration.component.spec.ts
+++ b/client/src/app/registration/registration.component.spec.ts
@@ -7,8 +7,10 @@ import {User} from "oidc-client";
 import {Observable} from "rxjs";
 import {Account} from "../core/security.data";
 import {FormsModule} from "@angular/forms";
+import {Router} from "@angular/router";
 import SpyObj = jasmine.SpyObj;
 import createSpyObj = jasmine.createSpyObj;
+import createSpy = jasmine.createSpy;
 
 let registration: RegistrationComponent;
 let fixture: ComponentFixture<RegistrationComponent>;
@@ -25,7 +27,8 @@ function configureTestEnvironment(): void {
     imports: [FormsModule],
     providers: [
       {provide: AuthenticationService, useFactory: () => authenticationService},
-      {provide: AaiService, useFactory: () => aaiService}
+      {provide: AaiService, useFactory: () => aaiService},
+      {provide: Router, useValue: createSpy('Router')}
     ]
   })
 }

--- a/client/src/app/registration/registration.component.spec.ts
+++ b/client/src/app/registration/registration.component.spec.ts
@@ -5,6 +5,7 @@ import {AuthenticationService} from "../core/authentication.service";
 import {AaiService} from "../aai/aai.service";
 import {User} from "oidc-client";
 import {Observable} from "rxjs";
+import {Account} from "../core/security.data";
 import SpyObj = jasmine.SpyObj;
 import createSpyObj = jasmine.createSpyObj;
 
@@ -22,7 +23,7 @@ function configureTestEnvironment(): void {
     declarations: [RegistrationComponent],
     providers: [
       {provide: AuthenticationService, useFactory: () => authenticationService},
-      {provide: AaiService, useFactory: () => aaiService},
+      {provide: AaiService, useFactory: () => aaiService}
     ]
   })
 }
@@ -45,11 +46,16 @@ describe('Registration', () => {
     aaiService.getUser.and.returnValue(Observable.of(user));
     registration.termsAccepted = true;
 
+    //and:
+    const newAccount = <Account>{id: '11f1faa8', providerReference: '2367ded12'};
+    authenticationService.register.and.returnValue(Promise.resolve(newAccount));
+
     //when:
     registration.proceed();
 
     //then:
     expect(authenticationService.register).toHaveBeenCalledWith(accessToken);
+    expect(registration.status.success).toBeTruthy();
   }));
 
   it('should NOT proceed if terms are not accepted', async(() => {

--- a/client/src/app/registration/registration.component.spec.ts
+++ b/client/src/app/registration/registration.component.spec.ts
@@ -68,8 +68,8 @@ describe('Registration', () => {
     registration.termsAccepted = true;
 
     //and:
-    const error = <RegistrationFailed>{errorCode: RegistrationErrorCode.Duplication}
-    const accountPromise = Promise.reject(error);
+    const failure = <RegistrationFailed>{errorCode: RegistrationErrorCode.Duplication}
+    const accountPromise = Promise.reject(failure);
     authenticationService.register.and.returnValue(accountPromise);
 
     //when:
@@ -79,7 +79,7 @@ describe('Registration', () => {
     flushMicrotasks();
     expect(authenticationService.register).toHaveBeenCalledWith(accessToken);
     expect(registration.status.success).toEqual(false);
-    expect(registration.status.message).toEqual(error.message);
+    expect(registration.status.errorCode).toEqual(failure.errorCode);
   }));
 
   it('should NOT proceed if terms are not accepted', async(() => {

--- a/client/src/app/registration/registration.component.ts
+++ b/client/src/app/registration/registration.component.ts
@@ -1,0 +1,15 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-registration',
+  templateUrl: './registration.component.html',
+  styleUrls: ['./registration.component.css']
+})
+export class RegistrationComponent implements OnInit {
+
+  constructor() { }
+
+  ngOnInit() {
+  }
+
+}

--- a/client/src/app/registration/registration.component.ts
+++ b/client/src/app/registration/registration.component.ts
@@ -5,6 +5,7 @@ import {User} from "oidc-client";
 
 interface RegistrationStatus {
   success: boolean;
+  message: string;
 }
 
 @Component({
@@ -34,6 +35,7 @@ export class RegistrationComponent implements OnInit {
           })
           .catch((error: DuplicateAccount) => {
             this.status.success = false;
+            this.status.message = error.message;
           });
       }
     })

--- a/client/src/app/registration/registration.component.ts
+++ b/client/src/app/registration/registration.component.ts
@@ -1,11 +1,21 @@
 import {Component, OnInit} from '@angular/core';
-import {AuthenticationService, RegistrationFailed} from "../core/authentication.service";
+import {AuthenticationService, RegistrationErrorCode, RegistrationFailed} from "../core/authentication.service";
 import {AaiService} from "../aai/aai.service";
 import {User} from "oidc-client";
 
+const messages = {
+  success: 'Your account was successfully created. Click OK to return to the home page.',
+  error: {
+    [RegistrationErrorCode.Duplication]:
+      'An account using your profile is already registered. Please check with the administrator for help.',
+    [RegistrationErrorCode.ServiceError]:
+      'Registration failed due to a service error. Please check back again, or contact support.'
+  }
+}
+
 interface RegistrationStatus {
   success: boolean;
-  errorCode: string;
+  message: string;
 }
 
 @Component({
@@ -32,10 +42,11 @@ export class RegistrationComponent implements OnInit {
         this.authenticationService.register(user.access_token)
           .then(() => {
             this.status.success = true;
+            this.status.message = messages.success;
           })
           .catch((failure: RegistrationFailed) => {
             this.status.success = false;
-            this.status.errorCode = failure.errorCode;
+            this.status.message = messages.error[failure.errorCode];
           });
       }
     })

--- a/client/src/app/registration/registration.component.ts
+++ b/client/src/app/registration/registration.component.ts
@@ -5,7 +5,7 @@ import {User} from "oidc-client";
 
 interface RegistrationStatus {
   success: boolean;
-  message: string;
+  errorCode: string;
 }
 
 @Component({
@@ -33,9 +33,9 @@ export class RegistrationComponent implements OnInit {
           .then(() => {
             this.status.success = true;
           })
-          .catch((error: RegistrationFailed) => {
+          .catch((failure: RegistrationFailed) => {
             this.status.success = false;
-            this.status.message = error.message;
+            this.status.errorCode = failure.errorCode;
           });
       }
     })

--- a/client/src/app/registration/registration.component.ts
+++ b/client/src/app/registration/registration.component.ts
@@ -1,5 +1,5 @@
 import {Component, OnInit} from '@angular/core';
-import {AuthenticationService, DuplicateAccount} from "../core/authentication.service";
+import {AuthenticationService, RegistrationFailed} from "../core/authentication.service";
 import {AaiService} from "../aai/aai.service";
 import {User} from "oidc-client";
 
@@ -33,7 +33,7 @@ export class RegistrationComponent implements OnInit {
           .then(() => {
             this.status.success = true;
           })
-          .catch((error: DuplicateAccount) => {
+          .catch((error: RegistrationFailed) => {
             this.status.success = false;
             this.status.message = error.message;
           });

--- a/client/src/app/registration/registration.component.ts
+++ b/client/src/app/registration/registration.component.ts
@@ -3,6 +3,10 @@ import {AuthenticationService} from "../core/authentication.service";
 import {AaiService} from "../aai/aai.service";
 import {User} from "oidc-client";
 
+interface RegistrationStatus {
+  success: boolean;
+}
+
 @Component({
   selector: 'app-registration',
   templateUrl: './registration.component.html',
@@ -11,6 +15,7 @@ import {User} from "oidc-client";
 export class RegistrationComponent implements OnInit {
 
   termsAccepted: boolean = false;
+  status: RegistrationStatus;
 
   constructor(private aaiService: AaiService,
               private authenticationService: AuthenticationService) {
@@ -23,6 +28,7 @@ export class RegistrationComponent implements OnInit {
     this.aaiService.getUser().subscribe((user: User) => {
       if (this.termsAccepted) {
         this.authenticationService.register(user.access_token);
+        this.status = <RegistrationStatus>{success: true};
       }
     })
   }

--- a/client/src/app/registration/registration.component.ts
+++ b/client/src/app/registration/registration.component.ts
@@ -7,9 +7,13 @@ import { Component, OnInit } from '@angular/core';
 })
 export class RegistrationComponent implements OnInit {
 
-  constructor() { }
+  termsAccepted: boolean = false;
 
-  ngOnInit() {
+  constructor() {}
+
+  ngOnInit() {}
+
+  acceptTerms() {
+    this.termsAccepted = !this.termsAccepted;
   }
-
 }

--- a/client/src/app/registration/registration.component.ts
+++ b/client/src/app/registration/registration.component.ts
@@ -19,10 +19,6 @@ export class RegistrationComponent implements OnInit {
   ngOnInit() {
   }
 
-  acceptTerms() {
-    this.termsAccepted = !this.termsAccepted;
-  }
-
   proceed() {
     this.aaiService.getUser().subscribe((user: User) => {
       if (this.termsAccepted) {

--- a/client/src/app/registration/registration.component.ts
+++ b/client/src/app/registration/registration.component.ts
@@ -2,6 +2,7 @@ import {Component, OnInit} from '@angular/core';
 import {AuthenticationService, RegistrationErrorCode, RegistrationFailed} from "../core/authentication.service";
 import {AaiService} from "../aai/aai.service";
 import {User} from "oidc-client";
+import {Router} from "@angular/router";
 
 const messages = {
   success: 'Your account was successfully created. Click OK to return to the home page.',
@@ -29,7 +30,8 @@ export class RegistrationComponent implements OnInit {
   status: RegistrationStatus;
 
   constructor(private aaiService: AaiService,
-              private authenticationService: AuthenticationService) {
+              private authenticationService: AuthenticationService,
+              private router: Router) {
   }
 
   ngOnInit() {

--- a/client/src/app/registration/registration.component.ts
+++ b/client/src/app/registration/registration.component.ts
@@ -1,4 +1,7 @@
-import { Component, OnInit } from '@angular/core';
+import {Component, OnInit} from '@angular/core';
+import {AuthenticationService} from "../core/authentication.service";
+import {AaiService} from "../aai/aai.service";
+import {User} from "oidc-client";
 
 @Component({
   selector: 'app-registration',
@@ -9,11 +12,22 @@ export class RegistrationComponent implements OnInit {
 
   termsAccepted: boolean = false;
 
-  constructor() {}
+  constructor(private aaiService: AaiService,
+              private authenticationService: AuthenticationService) {
+  }
 
-  ngOnInit() {}
+  ngOnInit() {
+  }
 
   acceptTerms() {
     this.termsAccepted = !this.termsAccepted;
+  }
+
+  proceed() {
+    this.aaiService.getUser().subscribe((user: User) => {
+      if (this.termsAccepted) {
+        this.authenticationService.register(user.access_token);
+      }
+    })
   }
 }

--- a/client/src/app/registration/registration.component.ts
+++ b/client/src/app/registration/registration.component.ts
@@ -1,5 +1,5 @@
 import {Component, OnInit} from '@angular/core';
-import {AuthenticationService} from "../core/authentication.service";
+import {AuthenticationService, DuplicateAccount} from "../core/authentication.service";
 import {AaiService} from "../aai/aai.service";
 import {User} from "oidc-client";
 
@@ -27,8 +27,14 @@ export class RegistrationComponent implements OnInit {
   proceed() {
     this.aaiService.getUser().subscribe((user: User) => {
       if (this.termsAccepted) {
-        this.authenticationService.register(user.access_token);
-        this.status = <RegistrationStatus>{success: true};
+        this.status = <RegistrationStatus>{};
+        this.authenticationService.register(user.access_token)
+          .then(() => {
+            this.status.success = true;
+          })
+          .catch((error: DuplicateAccount) => {
+            this.status.success = false;
+          });
       }
     })
   }

--- a/client/src/app/submitter/welcome/welcome.component.spec.ts
+++ b/client/src/app/submitter/welcome/welcome.component.spec.ts
@@ -24,7 +24,6 @@ describe('WelcomeComponent', () => {
       imports: [RouterTestingModule],
       declarations: [
         WelcomeComponent,
-        NewSubmissionComponent,
       ],
       providers: [
         {provide: AaiService, useValue: mockAaiSvc},

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -18,6 +18,7 @@
       "dom"
     ],
     "module": "esnext",
-    "baseUrl": "./"
+    "baseUrl": "./",
+    "resolveJsonModule": true
   }
 }


### PR DESCRIPTION
Modified the sign-in procedure to check if the User has a registered Account in Ingest Core. For Users that have yet to sign-up, the UI redirects them to the registration page.

The registration page refers to some terms and condition that are yet to be provided.