### PR TITLE
User Guard and Form Confirmation Bug Fixes

### DIFF
--- a/client/src/app/metadata-schema-form/metadata-field-types/enum-list-input/enum-list-input.component.ts
+++ b/client/src/app/metadata-schema-form/metadata-field-types/enum-list-input/enum-list-input.component.ts
@@ -67,10 +67,8 @@ export class EnumListInputComponent implements OnInit {
   }
 
   removeFormControl(i: number) {
-    if (confirm('Are you sure?')) {
-      const formArray = this.control as FormArray;
-      formArray.removeAt(i);
-    }
+    const formArray = this.control as FormArray;
+    formArray.removeAt(i);
   }
 
   addFormControl(value: string) {

--- a/client/src/app/metadata-schema-form/metadata-field-types/input/input.component.ts
+++ b/client/src/app/metadata-schema-form/metadata-field-types/input/input.component.ts
@@ -29,8 +29,10 @@ export class InputComponent implements OnInit {
   }
 
   removeFormControl(control: AbstractControl, i: number) {
-    const formArray = control as FormArray;
-    formArray.removeAt(i);
+    if (confirm('Are you sure?')) {
+      const formArray = control as FormArray;
+      formArray.removeAt(i);
+    }
   }
 
   addFormControl(metadata: Metadata, formControl: AbstractControl) {

--- a/client/src/app/metadata-schema-form/metadata-field-types/input/input.component.ts
+++ b/client/src/app/metadata-schema-form/metadata-field-types/input/input.component.ts
@@ -29,10 +29,8 @@ export class InputComponent implements OnInit {
   }
 
   removeFormControl(control: AbstractControl, i: number) {
-    if (confirm('Are you sure?')) {
-      const formArray = control as FormArray;
-      formArray.removeAt(i);
-    }
+    const formArray = control as FormArray;
+    formArray.removeAt(i);
   }
 
   addFormControl(metadata: Metadata, formControl: AbstractControl) {

--- a/client/src/app/metadata-schema-form/metadata-field-types/ontology-list-input/ontology-list-input.component.ts
+++ b/client/src/app/metadata-schema-form/metadata-field-types/ontology-list-input/ontology-list-input.component.ts
@@ -21,10 +21,8 @@ export class OntologyListInputComponent extends OntologyBaseComponent implements
   }
 
   removeFormControl(i: number) {
-    if (confirm('Are you sure?')) {
-      const formArray = this.control as FormArray;
-      formArray.removeAt(i);
-    }
+    const formArray = this.control as FormArray;
+    formArray.removeAt(i);
   }
 
   addFormControl(ontology: Ontology) {

--- a/client/src/app/shared/guards/wrangler-or-owner.guard.ts
+++ b/client/src/app/shared/guards/wrangler-or-owner.guard.ts
@@ -18,12 +18,13 @@ export class WranglerOrOwnerGuard implements CanActivate {
   canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<boolean | UrlTree> {
     let accessChecks: Observable<boolean>;
     let getProject: Observable<any>;
-    if (route.url.map(url => url.path).includes('projects') && route.queryParams.hasOwnProperty('uuid')) {
-      getProject = this.ingestService.getProjectByUuid(route.queryParams.uuid);
-    } else if (route.url.map(url => url.path).includes('projects') && route.queryParams.hasOwnProperty('id')) {
-      getProject = this.ingestService.getProject(route.queryParams.id);
-    } else if (route.url.map(url => url.path).includes('submissions') && (route.queryParams.hasOwnProperty('project'))) {
-      getProject = this.ingestService.getProjectByUuid(route.queryParams.project);
+    let params = {...route.queryParams, ...route.params};
+    if (route.url.map(url => url.path).includes('projects') && params.hasOwnProperty('uuid')) {
+      getProject = this.ingestService.getProjectByUuid(params.uuid);
+    } else if (route.url.map(url => url.path).includes('projects') && params.hasOwnProperty('id')) {
+      getProject = this.ingestService.getProject(params.id);
+    } else if (route.url.map(url => url.path).includes('submissions') && (params.hasOwnProperty('project'))) {
+      getProject = this.ingestService.getProjectByUuid(params.project);
     }
     if (getProject) {
       accessChecks = this.isWranglerOrOwner(this.ingestService.getUserAccount(), getProject).catch(() => Observable.of(false));


### PR DESCRIPTION
Resolves [#144](https://github.com/ebi-ait/hca-ebi-dev-team/issues/144)
 - Owner guard would not retrieve project info from url with path params, fixed.
 - The confirmation dialog when removing an item from select many would remove the item from the screen but not the data if you clicked cancel. the confirmation gets in the way of user flow, so removed it.

Deployed to [Dev](https://ui.ingest.dev.archive.data.humancellatlas.org)