### PR TITLE
Feature: Login Redirect

### DIFF
--- a/client/src/app/login/login.component.ts
+++ b/client/src/app/login/login.component.ts
@@ -1,7 +1,6 @@
 import {Component, ViewEncapsulation} from '@angular/core';
-import {Router} from '@angular/router';
+import {ActivatedRoute, Router} from '@angular/router';
 import {AaiService} from '../aai/aai.service';
-import {AlertService} from '../shared/services/alert.service';
 
 @Component({
   selector: 'app-login',
@@ -10,23 +9,34 @@ import {AlertService} from '../shared/services/alert.service';
   encapsulation: ViewEncapsulation.None
 })
 export class LoginComponent {
+  redirect: string
 
   constructor(private aai: AaiService,
               private router: Router,
-              private alertService: AlertService) {
-    this.aai.isUserLoggedInAndFromEBI().subscribe(isLoggedInAndFromEBI => {
-      if (isLoggedInAndFromEBI) {
-        alert('You are already logged in. Redirecting to homepage...');
-        this.router.navigate(['/home']);
+              private route: ActivatedRoute) {
+    this.redirect = this.route.snapshot.queryParamMap.get('redirect');
+    this.aai.isUserLoggedIn().subscribe(isLoggedIn => {
+      if (isLoggedIn) {
+        this.navigate()
       }
     });
   }
 
   login(): void {
     this.aai.isUserLoggedIn().subscribe(isLoggedIn => {
-      if (!isLoggedIn) {
-        this.aai.startAuthentication();
+      if (isLoggedIn) {
+        this.navigate()
+      } else {
+        this.aai.startAuthentication(this.redirect);
       }
     });
+  }
+
+  navigate() {
+    if (this.redirect) {
+      this.router.navigateByUrl(this.redirect);
+    } else {
+      this.router.navigateByUrl('/home');
+    }
   }
 }

--- a/client/src/app/shared/guards/user-is-logged-in.guard.ts
+++ b/client/src/app/shared/guards/user-is-logged-in.guard.ts
@@ -13,6 +13,6 @@ export class UserIsLoggedInGuard implements CanActivate {
   }
 
   canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<boolean | UrlTree> {
-    return this.aai.isUserLoggedIn().map(loggedIn => loggedIn ? loggedIn : this.router.parseUrl('/login'));
+    return this.aai.isUserLoggedIn().map(loggedIn => loggedIn ? loggedIn : this.router.parseUrl(`/login?redirect=${encodeURIComponent(state.url)}`));
   }
 }

--- a/client/src/app/shared/guards/user-is-wrangler.guard.ts
+++ b/client/src/app/shared/guards/user-is-wrangler.guard.ts
@@ -4,17 +4,23 @@ import {Observable} from 'rxjs';
 import {AaiSecurity} from '../../aai/aai.module';
 import {IngestService} from '../services/ingest.service';
 import {Account} from '../../core/account';
+import {AlertService} from "../services/alert.service";
 
 @Injectable({
   providedIn: AaiSecurity,
 })
 export class UserIsWranglerGuard implements CanActivate {
 
-  constructor(private ingestService: IngestService, private router: Router) {
+  constructor(private ingestService: IngestService, private alertService: AlertService, private router: Router) {
   }
 
   canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<boolean | UrlTree> {
     return this.ingestService.getUserAccount()
-      .map((account: Account) => account.isWrangler() ? true : this.router.parseUrl('/home'));
+      .map((account: Account) => account.isWrangler() || this.accessDenied(state.url) );
+  }
+
+  private accessDenied(url: string): UrlTree {
+    this.alertService.error('Access Denied', `You cannot access the resource: ${url}`, true, true)
+    return this.router.parseUrl('/home')
   }
 }


### PR DESCRIPTION
Implements ticket [#195](https://github.com/ebi-ait/hca-ebi-dev-team/issues/195)

Deployed to [Dev](https://ui.ingest.dev.archive.data.humancellatlas.org)

- Preserve the user's destination if interrupted by the login page.
- Raise a message when the user attempts to access resource they are not authorised to see:
    - Previously would simply fail to the home screen with no message.
    - Contributor's accessing wrangler pages.
    - Contributor's accessing other contributor's projects.
