### PR TITLE
Partial Project updates for Project registration

### DIFF
--- a/client/src/app/project-form/project-form.component.ts
+++ b/client/src/app/project-form/project-form.component.ts
@@ -213,7 +213,7 @@ export class ProjectFormComponent implements OnInit {
       return this.ingestService.postProject(this.patch)
         .pipe(
           concatMap(createdProject => {
-            return this.ingestService.patchProject(createdProject, this.patch) // save fields outside content
+            return this.ingestService.partialPatchProject(createdProject, this.patch) // save fields outside content
               .map(project => project as Project);
           }));
     } else {

--- a/client/src/app/project-form/project-form.component.ts
+++ b/client/src/app/project-form/project-form.component.ts
@@ -213,7 +213,7 @@ export class ProjectFormComponent implements OnInit {
       return this.ingestService.postProject(this.patch)
         .pipe(
           concatMap(createdProject => {
-            return this.ingestService.partialPatchProject(createdProject, this.patch) // save fields outside content
+            return this.ingestService.partiallyPatchProject(createdProject, this.patch) // save fields outside content
               .map(project => project as Project);
           }));
     } else {

--- a/client/src/app/project-registration/project-registration-form/project-registration-form.component.ts
+++ b/client/src/app/project-registration/project-registration-form/project-registration-form.component.ts
@@ -163,7 +163,7 @@ export class ProjectRegistrationFormComponent implements OnInit {
     console.log('formValue', formValue);
     this.patch = formValue;
     return this.ingestService.postProject(this.patch).pipe(concatMap(createdProject => {
-      return this.ingestService.patchProject(createdProject, this.patch) // save fields outside content
+      return this.ingestService.partialPatchProject(createdProject, this.patch) // save fields outside content
         .map(project => project as Project);
     }));
 

--- a/client/src/app/project-registration/project-registration-form/project-registration-form.component.ts
+++ b/client/src/app/project-registration/project-registration-form/project-registration-form.component.ts
@@ -163,7 +163,7 @@ export class ProjectRegistrationFormComponent implements OnInit {
     console.log('formValue', formValue);
     this.patch = formValue;
     return this.ingestService.postProject(this.patch).pipe(concatMap(createdProject => {
-      return this.ingestService.partialPatchProject(createdProject, this.patch) // save fields outside content
+      return this.ingestService.partiallyPatchProject(createdProject, this.patch) // save fields outside content
         .map(project => project as Project);
     }));
 

--- a/client/src/app/shared/services/ingest.service.ts
+++ b/client/src/app/shared/services/ingest.service.ts
@@ -97,7 +97,7 @@ export class IngestService {
     return this.doPatchProject(projectResource, patch);
   }
 
-  public partialPatchProject(projectResource, patch): Observable<Object> {
+  public partiallyPatchProject(projectResource, patch): Observable<Object> {
     return this.doPatchProject(projectResource, patch, true);
   }
 

--- a/client/src/app/shared/services/ingest.service.ts
+++ b/client/src/app/shared/services/ingest.service.ts
@@ -93,8 +93,8 @@ export class IngestService {
     return this.http.post(`${this.API_URL}/projects/query`, query, {params: params});
   }
 
-  public patchProject(projectResource, patch): Observable<Object> {
-    const projectLink: string = projectResource['_links']['self']['href'];
+  public patchProject(projectResource, patch, partial: boolean = false): Observable<Object> {
+    const projectLink: string = projectResource['_links']['self']['href'] + `?partial=${partial}`;
     patch['validationState'] = 'Draft';
     return this.http.patch(projectLink, patch);
   }

--- a/client/src/app/shared/services/ingest.service.ts
+++ b/client/src/app/shared/services/ingest.service.ts
@@ -93,7 +93,15 @@ export class IngestService {
     return this.http.post(`${this.API_URL}/projects/query`, query, {params: params});
   }
 
-  public patchProject(projectResource, patch, partial: boolean = false): Observable<Object> {
+  public patchProject(projectResource, patch): Observable<Object> {
+    return this.doPatchProject(projectResource, patch);
+  }
+
+  public partialPatchProject(projectResource, patch): Observable<Object> {
+    return this.doPatchProject(projectResource, patch, true);
+  }
+
+  private doPatchProject(projectResource, patch, partial: boolean = false): Observable<Object> {
     const projectLink: string = projectResource['_links']['self']['href'] + `?partial=${partial}`;
     patch['validationState'] = 'Draft';
     return this.http.patch(projectLink, patch);


### PR DESCRIPTION
Updated both the contributor and wrangler views of project registration to use partial updates mainly to avoid the system from sending more notifications than necessary.