### PR TITLE
Removed confirm popup

### DIFF
--- a/client/src/app/app.component.ts
+++ b/client/src/app/app.component.ts
@@ -37,8 +37,6 @@ export class AppComponent implements OnInit {
   }
 
   onLogout($event: any) {
-    if (confirm('Are you sure you want to logout?')) {
-      this.aai.logout();
-    }
+    this.aai.logout();
   }
 }


### PR DESCRIPTION
Part of the Elixir login/register flow review ([#298](https://app.zenhub.com/workspaces/ingest-dev-5cfe1cb26482e537cf35e8d1/issues/ebi-ait/hca-ebi-dev-team/298)), there's no need for an additional confirm popup since we're taken to the Elixir Logout Requested confirm page to confirm logout (which we can't skip!)