### PR TITLE
Allow for filtering by file validation error

### DIFF
--- a/client/src/app/shared/constants.ts
+++ b/client/src/app/shared/constants.ts
@@ -1,1 +1,10 @@
-export const INVALID_FILE_TYPES = ['Invalid Metadata', 'Invalid File', 'Not Uploaded'];
+export const INVALID_FILE_TYPES = [{
+  humanFriendly: 'Invalid Metadata',
+  code: 'METADATA_ERROR'
+}, {
+  humanFriendly: 'Invalid File',
+  code: 'FILE_ERROR'
+}, {
+  humanFriendly: 'Not Uploaded',
+  code: 'FILE_NOT_UPLOADED'
+}];

--- a/client/src/app/shared/constants.ts
+++ b/client/src/app/shared/constants.ts
@@ -1,0 +1,1 @@
+export const INVALID_FILE_TYPES = ['Invalid Metadata', 'Invalid File', 'Not Uploaded'];

--- a/client/src/app/shared/models/data-source.ts
+++ b/client/src/app/shared/models/data-source.ts
@@ -1,0 +1,6 @@
+import {Observable} from 'rxjs';
+
+export interface DataSource<T> {
+  connect(): Observable<any>;
+  disconnect(): void;
+}

--- a/client/src/app/shared/models/paginatedEndpoint.ts
+++ b/client/src/app/shared/models/paginatedEndpoint.ts
@@ -6,11 +6,11 @@ export interface Sort {
   direction: string;
 }
 
-export interface Params {
+export interface QueryData {
   sort?: Sort;
   page: number;
   size: number;
   [x: string]: any;
 }
 
-export type PaginatedEndpoint<T> = (params: Params) => Observable<PagedData<T>>;
+export type PaginatedEndpoint<T> = (params: QueryData) => Observable<PagedData<T>>;

--- a/client/src/app/shared/models/paginatedEndpoint.ts
+++ b/client/src/app/shared/models/paginatedEndpoint.ts
@@ -1,0 +1,16 @@
+import {Observable} from 'rxjs';
+import {PagedData} from './page';
+
+export interface Sort {
+  column: string;
+  direction: string;
+}
+
+export interface Params {
+  sort?: Sort;
+  page: number;
+  size: number;
+  [x: string]: any;
+}
+
+export type PaginatedEndpoint<T> = (params: Params) => Observable<PagedData<T>>;

--- a/client/src/app/shared/services/ingest.service.ts
+++ b/client/src/app/shared/services/ingest.service.ts
@@ -209,7 +209,7 @@ export class IngestService {
       .pipe(map(data => data._embedded && data._embedded.projects ? data._embedded.projects[0] : null));
   }
 
-  public fetchSubmissionData(submissionId, entityType, filterState, params): Observable<PagedData<MetadataDocument>> {
+  public fetchSubmissionData(submissionId, entityType, params): Observable<PagedData<MetadataDocument>> {
     let url = `${this.API_URL}/submissionEnvelopes/${submissionId}/${entityType}`;
     const submission_url = `${this.API_URL}/submissionEnvelopes/${submissionId}`;
 
@@ -217,14 +217,13 @@ export class IngestService {
     if (sort) {
       url = `${this.API_URL}/${entityType}/search/findBySubmissionEnvelope`;
       params['envelopeUri'] = encodeURIComponent(submission_url);
-      params['sort'] = `${sort['column']},${sort['dir']}`;
+      params['sort'] = `${sort['column']},${sort['direction']}`;
     }
 
-    if (filterState) {
+    if (params.filterState) {
       url = `${this.API_URL}/${entityType}/search/findBySubmissionEnvelopeAndValidationState`;
       params['envelopeUri'] = encodeURIComponent(submission_url);
-      params['state'] = filterState.toUpperCase();
-
+      params['state'] = params.filterState.toUpperCase();
     }
     return this.http
       .get<ListResult<MetadataDocument>>(url, {params: params})

--- a/client/src/app/shared/services/ingest.service.ts
+++ b/client/src/app/shared/services/ingest.service.ts
@@ -221,6 +221,10 @@ export class IngestService {
       params['sort'] = `${sort['column']},${sort['direction']}`;
     }
 
+    if (params.filterState && params.fileValidationTypeFilter) {
+      throw new Error('Cannot have both filterState and fileValidationTypeFilter.');
+    }
+
     if (params.filterState) {
       url = `${this.API_URL}/${entityType}/search/findBySubmissionEnvelopeAndValidationState`;
       params['envelopeUri'] = encodeURIComponent(submission_url);

--- a/client/src/app/shared/services/ingest.service.ts
+++ b/client/src/app/shared/services/ingest.service.ts
@@ -240,7 +240,7 @@ export class IngestService {
         throw new Error('Only files can be filtered by validation type.');
       }
 
-      url = `${this.API_URL}/files/search/findBySubmissionIdAndErrorType`;
+      url = `${this.API_URL}/files/search/findBySubmissionEnvelopeIdAndErrorType`;
       const fileValidationTypeFilter = INVALID_FILE_TYPES.find(type => type.humanFriendly === params.filterState).code;
       delete params.filterState; // Don't want to include this in the request
       params.errorType = fileValidationTypeFilter;

--- a/client/src/app/submission/files/files.component.html
+++ b/client/src/app/submission/files/files.component.html
@@ -1,10 +1,9 @@
-<div *ngIf="submissionEnvelopeId">
+<div *ngIf="submissionEnvelope">
   <div class="card">
     <div class="card-body" >
       <div class="row">
         <div class="col-lg-12">
-          <app-metadata-list [submissionEnvelopeId]="submissionEnvelopeId"
-                             [metadataType]="'files'"
+          <app-metadata-list [dataSource]="dataSource"
                              [config]="{displayLinking: true}"
                              [expectedCount]="manifest ? manifest['expectedFiles']: null">
           </app-metadata-list>

--- a/client/src/app/submission/files/files.component.ts
+++ b/client/src/app/submission/files/files.component.ts
@@ -6,8 +6,8 @@ import {Component, Input, OnInit} from '@angular/core';
   styleUrls: ['./files.component.css']
 })
 export class FilesComponent implements OnInit {
-  @Input() submissionEnvelopeId;
   @Input() submissionEnvelope;
+  @Input() dataSource;
   @Input() files$;
   @Input() manifest;
 

--- a/client/src/app/submission/metadata-data-source.ts
+++ b/client/src/app/submission/metadata-data-source.ts
@@ -32,10 +32,8 @@ export class MetadataDataSource<T> implements MetadataDataSource<T> {
   public loading$ = this.loading.asObservable();
   private isPolling: boolean;
 
-  constructor(protected endpoint: PaginatedEndpoint<PagedData<T>>,
-              protected resourceType: string) {
+  constructor(protected endpoint: PaginatedEndpoint<PagedData<T>>) {
     this.endpoint = endpoint;
-    this.resourceType = resourceType;
   }
 
   fetch(page: number): void {
@@ -78,5 +76,13 @@ export class MetadataDataSource<T> implements MetadataDataSource<T> {
 
   disconnect(): void {
     this.isPolling = false;
+  }
+}
+
+export class SubmissionDataSource<T> extends MetadataDataSource<T> {
+  constructor(protected endpoint: PaginatedEndpoint<PagedData<T>>,
+              resourceType: string) {
+    super(endpoint);
+    this.resourceType = resourceType;
   }
 }

--- a/client/src/app/submission/metadata-data-source.ts
+++ b/client/src/app/submission/metadata-data-source.ts
@@ -78,10 +78,10 @@ export class MetadataDataSource<T> extends PaginatedDataSource<T> {
   }
 
   public filterByState(state: string) {
-    this.setQueryData({ ...this.getQueryData(), filterState: state });
+    this.setQueryData({ ...this.getQueryData(), filterState: state, page: 0 });
   }
 
   public filterByFileValidationType(fileValidationType: string) {
-    this.setQueryData({ ...this.getQueryData(), fileValidationTypeFilter: fileValidationType });
+    this.setQueryData({ ...this.getQueryData(), fileValidationTypeFilter: fileValidationType, page: 0 });
   }
 }

--- a/client/src/app/submission/metadata-data-source.ts
+++ b/client/src/app/submission/metadata-data-source.ts
@@ -1,7 +1,7 @@
 import { DataSource } from '@angular/cdk/collections';
 import {BehaviorSubject, Observable, Subject, timer} from 'rxjs';
 import {IngestService} from '../shared/services/ingest.service';
-import {delay, map, repeat, share, startWith, switchMap, takeUntil, takeWhile, tap} from 'rxjs/operators';
+import {map, switchMap, takeWhile, tap} from 'rxjs/operators';
 import {ListResult} from '../shared/models/hateoas';
 import {PagedData} from '../shared/models/page';
 
@@ -32,6 +32,11 @@ export class MetadataDataSource<T> implements MetadataDataSource<T> {
 
   sortBy(column = '', direction = ''): void {
     this.sort.next({column, direction});
+  }
+
+  filterByState(state: string): void {
+    // TODO
+    console.warn('implement filterByState');
   }
 
   private fetchPage(params?: any): Observable<PagedData<T>> {

--- a/client/src/app/submission/metadata-data-source.ts
+++ b/client/src/app/submission/metadata-data-source.ts
@@ -3,6 +3,7 @@ import {pluck, switchMap, takeWhile, tap} from 'rxjs/operators';
 import {PagedData} from '../shared/models/page';
 import { DataSource } from '../shared/models/data-source';
 import {PaginatedEndpoint, Params} from '../shared/models/paginatedEndpoint';
+import {INVALID_FILE_TYPES} from '../shared/constants';
 
 export class PaginatedDataSource<T> implements DataSource<T> {
   protected params: BehaviorSubject<Params>;
@@ -75,5 +76,9 @@ export class MetadataDataSource<T> extends PaginatedDataSource<T> {
 
   public filterByState(state: string) {
     this.setParams({ ...this.params.getValue(), filterState: state });
+  }
+
+  public filterByFileValidationType(fileValidationType: string) {
+    this.setParams({ ...this.params.getValue(), fileValidationTypeFilter: fileValidationType });
   }
 }

--- a/client/src/app/submission/metadata-data-source.ts
+++ b/client/src/app/submission/metadata-data-source.ts
@@ -1,0 +1,56 @@
+import { DataSource } from '@angular/cdk/collections';
+import {BehaviorSubject, Observable, Subject} from 'rxjs';
+import {IngestService} from '../shared/services/ingest.service';
+import {map, share, startWith, switchMap} from 'rxjs/operators';
+import {ListResult} from '../shared/models/hateoas';
+import {PagedData} from '../shared/models/page';
+
+// TODO Move these interfacts to another file
+export interface MetadataDataSource<T> {
+  connect(): Observable<PagedData<T>>;
+  fetch(page: number): void;
+  disconnect(): void;
+}
+
+export class MetadataDataSource<T> implements MetadataDataSource<T> {
+  pageNumber: Subject<number>;
+  constructor(protected ingestService: IngestService,
+              protected endpoint: string,
+              protected resourceType: string,) {
+    this.endpoint = endpoint;
+    this.resourceType = resourceType;
+  }
+
+  fetch(page: number): void {
+    this.pageNumber.next(page);
+  }
+
+  private fetchPage(params?: any): Observable<PagedData<T>> {
+    return this.ingestService.get(this.endpoint, {params: params}).pipe(
+      map(data => data as ListResult<any>),
+      map(data => {
+        return {
+          data: data && data._embedded ? data._embedded[this.resourceType] : [],
+          page: data.page
+        };
+      })
+    );
+  }
+
+  connect(): Observable<PagedData<T>>  {
+    this.pageNumber = new Subject();
+    return this.pageNumber.pipe(
+      startWith(0),
+      switchMap(page => {
+        return this.fetchPage({
+            page: page,
+            size: 20,
+            sort: ''
+          }
+        );
+      })
+    );
+  }
+
+  disconnect(): void {}
+}

--- a/client/src/app/submission/metadata-data-source.ts
+++ b/client/src/app/submission/metadata-data-source.ts
@@ -30,6 +30,8 @@ export class MetadataDataSource<T> implements MetadataDataSource<T> {
   protected params: BehaviorSubject<Params>;
   private loading = new Subject<boolean>();
   public loading$ = this.loading.asObservable();
+  private polling = new Subject<boolean>();
+  public polling$ = this.polling.asObservable();
   private isPolling: boolean;
 
   constructor(protected endpoint: PaginatedEndpoint<PagedData<T>>) {
@@ -65,10 +67,12 @@ export class MetadataDataSource<T> implements MetadataDataSource<T> {
     if (shouldPoll) {
       this.isPolling = true;
       return timer(0, pollInterval).pipe(
+        tap(() => this.polling.next(true)),
         takeWhile(() => this.isPolling),
         switchMap(() => {
           return page$;
-        })
+        }),
+        tap(() => this.polling.next(false))
       );
     }
     return page$;

--- a/client/src/app/submission/metadata-data-source.ts
+++ b/client/src/app/submission/metadata-data-source.ts
@@ -1,5 +1,5 @@
 import {BehaviorSubject, Observable, Subject, timer} from 'rxjs';
-import {switchMap, takeWhile, tap} from 'rxjs/operators';
+import {pluck, switchMap, takeWhile, tap} from 'rxjs/operators';
 import {PagedData} from '../shared/models/page';
 import { DataSource } from '../shared/models/data-source';
 import {PaginatedEndpoint, Params} from '../shared/models/paginatedEndpoint';
@@ -11,6 +11,7 @@ export class PaginatedDataSource<T> implements DataSource<T> {
   private polling = new Subject<boolean>();
   public polling$ = this.polling.asObservable();
   private isPolling: boolean;
+  public page$: Observable<number>;
 
   constructor(protected endpoint: PaginatedEndpoint<T>) {
     this.endpoint = endpoint;
@@ -33,6 +34,8 @@ export class PaginatedDataSource<T> implements DataSource<T> {
       page: 0,
       size: 20
     });
+
+    this.page$ = this.params.pipe(pluck('page'));
 
     const page$ = this.params.pipe(
       tap(() => this.loading.next(true)),

--- a/client/src/app/submission/metadata-data-source.ts
+++ b/client/src/app/submission/metadata-data-source.ts
@@ -78,10 +78,10 @@ export class MetadataDataSource<T> extends PaginatedDataSource<T> {
   }
 
   public filterByState(state: string) {
-    this.setQueryData({ ...this.getQueryData(), filterState: state, page: 0 });
+    this.setQueryData({ ...this.getQueryData(), fileValidationTypeFilter: null, filterState: state, page: 0 });
   }
 
   public filterByFileValidationType(fileValidationType: string) {
-    this.setQueryData({ ...this.getQueryData(), fileValidationTypeFilter: fileValidationType, page: 0 });
+    this.setQueryData({ ...this.getQueryData(), fileValidationTypeFilter: fileValidationType, filterState: null, page: 0 });
   }
 }

--- a/client/src/app/submission/metadata-data-source.ts
+++ b/client/src/app/submission/metadata-data-source.ts
@@ -1,32 +1,10 @@
-import { DataSource } from '@angular/cdk/collections';
 import {BehaviorSubject, Observable, Subject, timer} from 'rxjs';
-import {IngestService} from '../shared/services/ingest.service';
-import {map, switchMap, takeWhile, tap} from 'rxjs/operators';
-import {ListResult} from '../shared/models/hateoas';
+import {switchMap, takeWhile, tap} from 'rxjs/operators';
 import {PagedData} from '../shared/models/page';
+import { DataSource } from '../shared/models/data-source';
+import {PaginatedEndpoint, Params} from '../shared/models/paginatedEndpoint';
 
-// TODO Move these interfacts to another file
-export interface MetadataDataSource<T> {
-  connect(): Observable<PagedData<T>>;
-  fetch(page: number): void;
-  disconnect(): void;
-}
-
-export interface Sort {
-  column: string;
-  direction: string;
-}
-
-export interface Params {
-  sort?: Sort;
-  page: number;
-  size: number;
-  [x: string]: any;
-}
-
-export type PaginatedEndpoint<T> = (params: Params) => Observable<T>;
-
-export class MetadataDataSource<T> implements MetadataDataSource<T> {
+export class PaginatedDataSource<T> implements DataSource<T> {
   protected params: BehaviorSubject<Params>;
   private loading = new Subject<boolean>();
   public loading$ = this.loading.asObservable();
@@ -34,7 +12,7 @@ export class MetadataDataSource<T> implements MetadataDataSource<T> {
   public polling$ = this.polling.asObservable();
   private isPolling: boolean;
 
-  constructor(protected endpoint: PaginatedEndpoint<PagedData<T>>) {
+  constructor(protected endpoint: PaginatedEndpoint<T>) {
     this.endpoint = endpoint;
   }
 
@@ -83,9 +61,9 @@ export class MetadataDataSource<T> implements MetadataDataSource<T> {
   }
 }
 
-export class SubmissionDataSource<T> extends MetadataDataSource<T> {
+export class MetadataDataSource<T> extends PaginatedDataSource<T> {
   public resourceType: string;
-  constructor(protected endpoint: PaginatedEndpoint<PagedData<T>>,
+  constructor(protected endpoint: PaginatedEndpoint<T>,
               resourceType: string) {
     super(endpoint);
     this.resourceType = resourceType;

--- a/client/src/app/submission/metadata-data-source.ts
+++ b/client/src/app/submission/metadata-data-source.ts
@@ -27,7 +27,7 @@ export interface Params {
 export type PaginatedEndpoint<T> = (params: Params) => Observable<T>;
 
 export class MetadataDataSource<T> implements MetadataDataSource<T> {
-  private params: BehaviorSubject<Params>;
+  protected params: BehaviorSubject<Params>;
   private loading = new Subject<boolean>();
   public loading$ = this.loading.asObservable();
   private isPolling: boolean;
@@ -80,9 +80,14 @@ export class MetadataDataSource<T> implements MetadataDataSource<T> {
 }
 
 export class SubmissionDataSource<T> extends MetadataDataSource<T> {
+  public resourceType: string;
   constructor(protected endpoint: PaginatedEndpoint<PagedData<T>>,
               resourceType: string) {
     super(endpoint);
     this.resourceType = resourceType;
+  }
+
+  public filterByState(state: string) {
+    this.setParams({ ...this.params.getValue(), filterState: state });
   }
 }

--- a/client/src/app/submission/metadata-data-source.ts
+++ b/client/src/app/submission/metadata-data-source.ts
@@ -37,7 +37,8 @@ export class PaginatedDataSource<T> implements DataSource<T> {
     const page$ = this.params.pipe(
       tap(() => this.loading.next(true)),
       switchMap(params => {
-        return this.endpoint(params);
+        // Copy the params to remove side-effects
+        return this.endpoint(Object.assign({}, params));
       }),
       tap(() => this.loading.next(false))
     );

--- a/client/src/app/submission/metadata-list/metadata-list.component.html
+++ b/client/src/app/submission/metadata-list/metadata-list.component.html
@@ -33,7 +33,7 @@
 
   [count]="page.totalElements"
   [limit]="page.size"
-  [loadingIndicator]="isLoading"
+  [loadingIndicator]="dataSource.loading$ | async"
   [externalPaging]="isPaginated"
 
   (page)='setPage($event)'

--- a/client/src/app/submission/metadata-list/metadata-list.component.html
+++ b/client/src/app/submission/metadata-list/metadata-list.component.html
@@ -32,6 +32,7 @@
   [scrollbarH]="true"
 
   [count]="page.totalElements"
+  [offset]="dataSource.page$ | async"
   [limit]="page.size"
   [loadingIndicator]="(dataSource.loading$ | async) && !(dataSource.polling$ | async)"
   [externalPaging]="isPaginated"

--- a/client/src/app/submission/metadata-list/metadata-list.component.html
+++ b/client/src/app/submission/metadata-list/metadata-list.component.html
@@ -33,7 +33,7 @@
 
   [count]="page.totalElements"
   [limit]="page.size"
-  [loadingIndicator]="dataSource.loading$ | async"
+  [loadingIndicator]="(dataSource.loading$ | async) && !(dataSource.polling$ | async)"
   [externalPaging]="isPaginated"
 
   (page)='setPage($event)'

--- a/client/src/app/submission/metadata-list/metadata-list.component.ts
+++ b/client/src/app/submission/metadata-list/metadata-list.component.ts
@@ -25,7 +25,6 @@ export class MetadataListComponent implements OnInit, OnDestroy {
 
   @Input() title: string;
   @Input() metadataList;
-  @Input() metadataType;
   @Input() expectedCount;
   @Input() dataSource: any;
 
@@ -76,7 +75,7 @@ export class MetadataListComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit() {
-    this.dataSource.connect().subscribe(data => {
+      this.dataSource.connect().subscribe(data => {
       this.rows = data.data.map(row => this.flattenService.flatten(row));
       this.metadataList = data.data;
       if (data.page) {
@@ -145,7 +144,7 @@ export class MetadataListComponent implements OnInit, OnDestroy {
   getDefaultValidMessage() {
     let validMessage = '* Metadata is valid.';
 
-    if (this.metadataType === 'files') {
+    if (this.dataSource.resourceType === 'files') {
       validMessage = '* Data is valid.';
     }
 
@@ -205,21 +204,21 @@ export class MetadataListComponent implements OnInit, OnDestroy {
   }
 
   showFilterState() {
-    return this.metadataType !== 'bundleManifests';
+    return this.dataSource.resourceType !== 'bundleManifests';
   }
 
   onSort(event) {
-    // TODO: move to data source
     const sorts = event.sorts;
 
     const column = sorts[0]['prop']; // only one column sorting is supported for now
     const dir = sorts[0]['dir'];
 
-    if (this.metadataType === 'files') { // only sorting in files are supported for now
+    if (this.dataSource.resourceType === 'files') { // only sorting in files are supported for now
       this.currentPageInfo['sort'] = {column: column, dir: dir};
-      this.setPage(this.currentPageInfo);
+      this.stopPolling();
+      this.dataSource.sortBy(column, dir);
+      this.startPolling();
     }
-
   }
 
   getRowId(row) {

--- a/client/src/app/submission/metadata-list/metadata-list.component.ts
+++ b/client/src/app/submission/metadata-list/metadata-list.component.ts
@@ -27,6 +27,7 @@ export class MetadataListComponent implements OnInit, OnDestroy {
   @Input() metadataList;
   @Input() metadataType;
   @Input() expectedCount;
+  @Input() dataSource: any;
 
   private _config = {
     displayContent: true,
@@ -175,16 +176,18 @@ export class MetadataListComponent implements OnInit, OnDestroy {
   }
 
   fetchData(pageInfo) {
-    if (this.submissionEnvelopeId) {
-      const params = {
-        page: pageInfo['offset'],
-        size: pageInfo['size'],
-        sort: pageInfo['sort']
-      };
+    const params = {
+      page: pageInfo['offset'],
+      size: pageInfo['size'],
+      sort: pageInfo['sort']
+    };
 
-      this.metadataList$ = this.ingestService.fetchSubmissionData(this.submissionEnvelopeId, this.metadataType, this.filterState, params);
-      this.metadataList$.subscribe(data => {
-        this.rows = data.data.map(this.flattenService.flatten);
+    this.isLoading = true;
+    // TODO: Change dataSource to use angular collection and extract common logic between here and DataTableComponent
+    return this.dataSource.fetchData(params).subscribe(
+      data => {
+        this.isLoading = false;
+        this.rows = data.data.map(row => this.flattenService.flatten(row));
         this.metadataList = data.data;
         if (data.page) {
           this.isPaginated = true;
@@ -192,21 +195,24 @@ export class MetadataListComponent implements OnInit, OnDestroy {
         } else {
           this.isPaginated = false;
         }
-      });
-    }
+      }
+    );
   }
 
   startPolling(pageInfo) {
+    // TODO: move polling to data source
     this.pollingSubscription = this.pollingTimer.subscribe(() => this.fetchData(pageInfo));
   }
 
   stopPolling() {
+    // TODO: move polling to data source
     if (this.pollingSubscription) {
       this.pollingSubscription.unsubscribe();
     }
   }
 
   filterByState(event) {
+    // TODO: move to data source
     this.filterState = event.value;
     this.setPage(this.currentPageInfo);
   }
@@ -216,6 +222,7 @@ export class MetadataListComponent implements OnInit, OnDestroy {
   }
 
   onSort(event) {
+    // TODO: move to data source
     const sorts = event.sorts;
 
     const column = sorts[0]['prop']; // only one column sorting is supported for now

--- a/client/src/app/submission/metadata-list/metadata-list.component.ts
+++ b/client/src/app/submission/metadata-list/metadata-list.component.ts
@@ -57,7 +57,6 @@ export class MetadataListComponent implements OnInit, OnDestroy {
   currentPageInfo: {};
   private alive: boolean;
   private pollInterval: number;
-  isLoading = false;
 
   constructor(private ingestService: IngestService,
               private flattenService: FlattenService,
@@ -78,7 +77,6 @@ export class MetadataListComponent implements OnInit, OnDestroy {
 
   ngOnInit() {
     this.dataSource.connect().subscribe(data => {
-      this.isLoading = false;
       this.rows = data.data.map(row => this.flattenService.flatten(row));
       this.metadataList = data.data;
       if (data.page) {
@@ -190,7 +188,6 @@ export class MetadataListComponent implements OnInit, OnDestroy {
     // TODO: move polling to data source
     this.pollingSubscription = this.pollingTimer.subscribe(() => {
       this.dataSource.fetch(this.page.number);
-      this.isLoading = true;
     });
   }
 

--- a/client/src/app/submission/metadata-list/metadata-list.component.ts
+++ b/client/src/app/submission/metadata-list/metadata-list.component.ts
@@ -51,7 +51,6 @@ export class MetadataListComponent implements OnInit, OnDestroy {
   isPaginated: boolean;
   validationStates: string[];
   filterState: string;
-  currentPageInfo: {};
 
   constructor(private ingestService: IngestService,
               private flattenService: FlattenService,
@@ -68,7 +67,7 @@ export class MetadataListComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit() {
-    this.dataSource.connect(true, 5000).subscribe(data => {
+    this.dataSource.connect(false, 5000).subscribe(data => {
       this.rows = data.data.map(row => this.flattenService.flatten(row));
       this.metadataList = data.data;
       if (data.page) {
@@ -168,7 +167,6 @@ export class MetadataListComponent implements OnInit, OnDestroy {
   }
 
   setPage(pageInfo) {
-    this.currentPageInfo = pageInfo;
     this.page.number = pageInfo.offset;
     this.dataSource.fetch(this.page.number);
   }
@@ -176,7 +174,6 @@ export class MetadataListComponent implements OnInit, OnDestroy {
   filterByState(event) {
     // TODO: move to data source
     this.filterState = event.value;
-    this.setPage(this.currentPageInfo);
   }
 
   showFilterState() {
@@ -190,7 +187,6 @@ export class MetadataListComponent implements OnInit, OnDestroy {
     const dir = sorts[0]['dir'];
 
     if (this.dataSource.resourceType === 'files') { // only sorting in files are supported for now
-      this.currentPageInfo['sort'] = {column: column, dir: dir};
       this.dataSource.sortBy(column, dir);
     }
   }

--- a/client/src/app/submission/metadata-list/metadata-list.component.ts
+++ b/client/src/app/submission/metadata-list/metadata-list.component.ts
@@ -67,7 +67,7 @@ export class MetadataListComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit() {
-    this.dataSource.connect(false, 5000).subscribe(data => {
+    this.dataSource.connect(true, 5000).subscribe(data => {
       this.rows = data.data.map(row => this.flattenService.flatten(row));
       this.metadataList = data.data;
       if (data.page) {

--- a/client/src/app/submission/metadata-list/metadata-list.component.ts
+++ b/client/src/app/submission/metadata-list/metadata-list.component.ts
@@ -1,6 +1,6 @@
 import {AfterViewChecked, Component, Input, OnDestroy, OnInit, ViewChild, ViewEncapsulation} from '@angular/core';
 import {Observable, of, Subscription, timer} from 'rxjs';
-import {takeWhile, tap} from 'rxjs/operators';
+import {filter, takeWhile, tap} from 'rxjs/operators';
 import {IngestService} from '../../shared/services/ingest.service';
 import {FlattenService} from '../../shared/services/flatten.service';
 import {Page, PagedData} from '../../shared/models/page';
@@ -9,6 +9,7 @@ import {MetadataDetailsDialogComponent} from '../../metadata-details-dialog/meta
 import {MatDialog} from '@angular/material/dialog';
 import {SchemaService} from '../../shared/services/schema.service';
 import {LoaderService} from '../../shared/services/loader.service';
+import {INVALID_FILE_TYPES} from '../../shared/constants';
 
 @Component({
   selector: 'app-metadata-list',
@@ -77,6 +78,11 @@ export class MetadataListComponent implements OnInit, OnDestroy {
         this.isPaginated = false;
       }
     });
+
+    if (this.dataSource.resourceType === 'files') {
+      this.validationStates = this.validationStates.concat(INVALID_FILE_TYPES);
+    }
+
     this.setPage({offset: 0});
   }
 
@@ -172,7 +178,14 @@ export class MetadataListComponent implements OnInit, OnDestroy {
   }
 
   filterByState(event) {
-    this.dataSource.filterByState(event.value);
+    const filterState = event.value;
+
+    if (INVALID_FILE_TYPES.includes(filterState)) {
+      this.dataSource.filterByFileValidationType(filterState);
+      return;
+    }
+
+    this.dataSource.filterByState(filterState);
   }
 
   showFilterState() {
@@ -220,6 +233,4 @@ export class MetadataListComponent implements OnInit, OnDestroy {
     const metadata = this.metadataList[rowIndex];
     this.table.rowDetail.toggleExpandRow(row);
   }
-
-
 }

--- a/client/src/app/submission/metadata-list/metadata-list.component.ts
+++ b/client/src/app/submission/metadata-list/metadata-list.component.ts
@@ -80,7 +80,7 @@ export class MetadataListComponent implements OnInit, OnDestroy {
     });
 
     if (this.dataSource.resourceType === 'files') {
-      this.validationStates = this.validationStates.concat(INVALID_FILE_TYPES);
+      this.validationStates = this.validationStates.concat(INVALID_FILE_TYPES.map(a => a.humanFriendly));
     }
 
     this.setPage({offset: 0});

--- a/client/src/app/submission/metadata-list/metadata-list.component.ts
+++ b/client/src/app/submission/metadata-list/metadata-list.component.ts
@@ -9,8 +9,6 @@ import {MetadataDetailsDialogComponent} from '../../metadata-details-dialog/meta
 import {MatDialog} from '@angular/material/dialog';
 import {SchemaService} from '../../shared/services/schema.service';
 import {LoaderService} from '../../shared/services/loader.service';
-import {ListResult} from '../../shared/models/hateoas';
-import {MetadataSchema} from '../../shared/models/metadata-schema';
 
 @Component({
   selector: 'app-metadata-list',

--- a/client/src/app/submission/metadata-list/metadata-list.component.ts
+++ b/client/src/app/submission/metadata-list/metadata-list.component.ts
@@ -172,8 +172,7 @@ export class MetadataListComponent implements OnInit, OnDestroy {
   }
 
   filterByState(event) {
-    // TODO: move to data source
-    this.filterState = event.value;
+    this.dataSource.filterByState(event.value);
   }
 
   showFilterState() {

--- a/client/src/app/submission/submission.component.html
+++ b/client/src/app/submission/submission.component.html
@@ -28,33 +28,6 @@
   <div>
     <div class="vf-text-body vf-text-body--2">{{projectTitle}}</div>
     <div class="vf-text-body vf-text-body--3">{{getContributors(project)}}</div>
-    <div>
-      <p>Your metadata validation returned <span class="error-text">24 errors</span>. Review and fix them below.</p>
-
-      <ul id="validation-error-types">
-        <li>
-          Biomaterials:
-          <a href="javascript: void(0)" (click)="navigateToTab(0)">
-            {{validationErrors.biomaterials.total}} errors
-          </a>
-        </li>
-        <li>
-          Processes:
-          <a href="javascript: void(0)"(click)="navigateToTab(1)">
-            {{validationErrors.processes.total}} errors
-          </a>
-        </li>
-        <li>
-          Data files:
-          <a href="javascript: void(0)" (click)="navigateToTab(3)">
-            {{validationErrors.files.metadataErrors}} errors
-          </a>,
-          <a href="javascript: void(0)" (click)="navigateToTab(3)">
-            {{validationErrors.files.fileMissing}} files missing
-          </a>
-        </li>
-      </ul>
-    </div>
     <div *ngIf=" project?.validationErrors && project?.validationErrors.length > 0">
       <span class="vf-text-body vf-text-body--3 vf-u-text-color--red">Project is Invalid. Please go back and edit the project.</span><br/>
       <ng-container *ngFor="let error of project?.validationErrors">

--- a/client/src/app/submission/submission.component.html
+++ b/client/src/app/submission/submission.component.html
@@ -88,14 +88,6 @@
       </ng-template>
     </mat-tab>
 
-    <mat-tab label="Errors" *ngIf="submissionErrors && submissionErrors.length > 0">
-      <ng-template matTabContent>
-        <br/>
-        <app-data-table [idColumn]="'instance'" [rows]="submissionErrors" [columns]="['title', 'detail', 'instance']">
-        </app-data-table>
-      </ng-template>
-    </mat-tab>
-
     <mat-tab label="Submit" [disabled]="!isValid"
              *ngIf="[ 'Submitted', 'Processing', 'Archiving', 'Exporting', 'Cleanup', 'Complete'].indexOf(submissionState) < 0">
       <ng-template matTabContent>

--- a/client/src/app/submission/submission.component.html
+++ b/client/src/app/submission/submission.component.html
@@ -68,20 +68,20 @@
   <mat-tab-group *ngIf="submissionEnvelopeId" [selectedIndex]="selectedIndex">
     <mat-tab label="Biomaterials">
       <ng-template matTabContent>
-        <app-metadata-list [submissionEnvelopeId]="submissionEnvelopeId" [metadataType]="'biomaterials'"
+        <app-metadata-list [dataSource]="biomaterialsDataSource"
                            [config]="{displayLinking: true}"
                            [expectedCount]="manifest ? manifest['expectedBiomaterials'] : null"></app-metadata-list>
       </ng-template>
     </mat-tab>
     <mat-tab label="Processes">
       <ng-template matTabContent>
-        <app-metadata-list [submissionEnvelopeId]="submissionEnvelopeId" [metadataType]="'processes'"
+        <app-metadata-list [dataSource]="processesDataSource"
                            [expectedCount]="manifest ? manifest['expectedProcesses'] : null"></app-metadata-list>
       </ng-template>
     </mat-tab>
     <mat-tab label="Protocols">
       <ng-template matTabContent>
-        <app-metadata-list [submissionEnvelopeId]="submissionEnvelopeId" [metadataType]="'protocols'"
+        <app-metadata-list [dataSource]="protocolsDataSource"
                            [config]="{displayLinking: true}"
                            [expectedCount]="manifest ? manifest['expectedProtocols'] : null"></app-metadata-list>
       </ng-template>
@@ -89,8 +89,8 @@
     <mat-tab label="Data" [disabled]="!submissionEnvelopeId">
       <ng-template matTabContent>
         <app-files
+          [dataSource]="filesDataSource"
           [submissionEnvelope]="submissionEnvelope"
-          [submissionEnvelopeId]="submissionEnvelopeId"
           [manifest]="manifest">
         </app-files>
       </ng-template>
@@ -98,8 +98,7 @@
     <mat-tab label="Assays" *ngIf="isSubmitted">
       <ng-template matTabContent>
         <app-metadata-list
-          [submissionEnvelopeId]="submissionEnvelopeId"
-          [metadataType]="'bundleManifests'"
+          [dataSource]="bundleManifestsDataSource"
           [config]="{displayAll: true, hideWhenEmptyRows: true}">
         </app-metadata-list>
       </ng-template>

--- a/client/src/app/submission/submission.component.html
+++ b/client/src/app/submission/submission.component.html
@@ -28,6 +28,15 @@
   <div>
     <div class="vf-text-body vf-text-body--2">{{projectTitle}}</div>
     <div class="vf-text-body vf-text-body--3">{{getContributors(project)}}</div>
+    <div>
+      <p>Your metadata validation returned 24 errors. Review and fix them below.</p>
+
+      <ul id="validation-error-types">
+        <li>Biomaterials: {{validationErrors.biomaterials.total}} errors</li>
+        <li>Processes: {{validationErrors.processes.total}} errors</li>
+        <li>Data files: {{validationErrors.files.metadataErrors}} errors, {{validationErrors.files.fileMissing}} files missing</li>
+      </ul>
+    </div>
     <div *ngIf=" project?.validationErrors && project?.validationErrors.length > 0">
       <span class="vf-text-body vf-text-body--3 vf-u-text-color--red">Project is Invalid. Please go back and edit the project.</span><br/>
       <ng-container *ngFor="let error of project?.validationErrors">

--- a/client/src/app/submission/submission.component.html
+++ b/client/src/app/submission/submission.component.html
@@ -29,7 +29,7 @@
     <div class="vf-text-body vf-text-body--2">{{projectTitle}}</div>
     <div class="vf-text-body vf-text-body--3">{{getContributors(project)}}</div>
     <div>
-      <p>Your metadata validation returned 24 errors. Review and fix them below.</p>
+      <p>Your metadata validation returned <span class="error-text">24 errors</span>. Review and fix them below.</p>
 
       <ul id="validation-error-types">
         <li>

--- a/client/src/app/submission/submission.component.html
+++ b/client/src/app/submission/submission.component.html
@@ -32,9 +32,27 @@
       <p>Your metadata validation returned 24 errors. Review and fix them below.</p>
 
       <ul id="validation-error-types">
-        <li>Biomaterials: {{validationErrors.biomaterials.total}} errors</li>
-        <li>Processes: {{validationErrors.processes.total}} errors</li>
-        <li>Data files: {{validationErrors.files.metadataErrors}} errors, {{validationErrors.files.fileMissing}} files missing</li>
+        <li>
+          Biomaterials:
+          <a href="javascript: void(0)" (click)="navigateToTab(0)">
+            {{validationErrors.biomaterials.total}} errors
+          </a>
+        </li>
+        <li>
+          Processes:
+          <a href="javascript: void(0)"(click)="navigateToTab(1)">
+            {{validationErrors.processes.total}} errors
+          </a>
+        </li>
+        <li>
+          Data files:
+          <a href="javascript: void(0)" (click)="navigateToTab(3)">
+            {{validationErrors.files.metadataErrors}} errors
+          </a>,
+          <a href="javascript: void(0)" (click)="navigateToTab(3)">
+            {{validationErrors.files.fileMissing}} files missing
+          </a>
+        </li>
       </ul>
     </div>
     <div *ngIf=" project?.validationErrors && project?.validationErrors.length > 0">

--- a/client/src/app/submission/submission.component.scss
+++ b/client/src/app/submission/submission.component.scss
@@ -1,3 +1,9 @@
 .mat-basic-chip{
   padding: 7px 12px;
 }
+
+#validation-error-types {
+  list-style: none;
+  padding: 0;
+  marging: 0;
+}

--- a/client/src/app/submission/submission.component.scss
+++ b/client/src/app/submission/submission.component.scss
@@ -1,3 +1,4 @@
+@import "../shared/components/submission-state/submission-state";
 .mat-basic-chip{
   padding: 7px 12px;
 }
@@ -6,4 +7,13 @@
   list-style: none;
   padding: 0;
   marging: 0;
+
+  a {
+    color: $danger-color;
+    text-decoration: none;
+    font-weight: 500;
+    &:hover {
+      text-decoration: underline;
+    }
+  }
 }

--- a/client/src/app/submission/submission.component.scss
+++ b/client/src/app/submission/submission.component.scss
@@ -3,15 +3,19 @@
   padding: 7px 12px;
 }
 
+.error-text {
+  color: $danger-color;
+  font-weight: 500;
+}
+
 #validation-error-types {
   list-style: none;
   padding: 0;
   marging: 0;
 
   a {
-    color: $danger-color;
+    @extend .error-text;
     text-decoration: none;
-    font-weight: 500;
     &:hover {
       text-decoration: underline;
     }

--- a/client/src/app/submission/submission.component.ts
+++ b/client/src/app/submission/submission.component.ts
@@ -2,7 +2,7 @@ import {Component, OnDestroy, OnInit} from '@angular/core';
 import {ActivatedRoute, Router} from '@angular/router';
 import {HttpErrorResponse} from '@angular/common/http';
 import {Observable, timer} from 'rxjs';
-import {distinctUntilChanged, filter, map, switchMap, takeWhile} from 'rxjs/operators';
+import {filter, takeWhile} from 'rxjs/operators';
 import {IngestService} from '../shared/services/ingest.service';
 import {AlertService} from '../shared/services/alert.service';
 import {SubmissionEnvelope} from '../shared/models/submissionEnvelope';
@@ -10,7 +10,6 @@ import {LoaderService} from '../shared/services/loader.service';
 import {BrokerService} from '../shared/services/broker.service';
 import {Project} from '../shared/models/project';
 import {ArchiveEntity} from '../shared/models/archiveEntity';
-import {ListResult} from '../shared/models/hateoas';
 import {IngestDataSource} from '../shared/components/data-table/data-source/ingest-data-source';
 
 

--- a/client/src/app/submission/submission.component.ts
+++ b/client/src/app/submission/submission.component.ts
@@ -317,12 +317,12 @@ export class SubmissionComponent implements OnInit, OnDestroy {
         return;
       }
       this[`${type}DataSource`] = new MetadataDataSource<any>(
-        this.ingestService,
-        this.submissionEnvelope._links[type].href,
+        (params) => this.ingestService.fetchSubmissionData(this.submissionEnvelopeId, type, params),
         type
       );
     });
   }
+
 
   private getSubmissionManifest() {
     this.ingestService.get(this.submissionEnvelope['_links']['submissionManifest']['href'])

--- a/client/src/app/submission/submission.component.ts
+++ b/client/src/app/submission/submission.component.ts
@@ -12,6 +12,7 @@ import {Project} from '../shared/models/project';
 import {ArchiveEntity} from '../shared/models/archiveEntity';
 import {IngestDataSource} from '../shared/components/data-table/data-source/ingest-data-source';
 import {MetadataDataSource} from './metadata-data-source';
+import {MetadataDocument} from '../shared/models/metadata-document';
 
 
 @Component({
@@ -44,11 +45,11 @@ export class SubmissionComponent implements OnInit, OnDestroy {
   validationErrors: any;
 
   // TODO: Give these a type
-  biomaterialsDataSource: any;
-  processesDataSource: any;
-  protocolsDataSource: any;
-  bundleManifestsDataSource: any;
-  filesDataSource: any;
+  biomaterialsDataSource: MetadataDataSource<MetadataDocument>;
+  processesDataSource: MetadataDataSource<MetadataDocument>;
+  protocolsDataSource: MetadataDataSource<MetadataDocument>;
+  bundleManifestsDataSource: MetadataDataSource<MetadataDocument>;
+  filesDataSource: MetadataDataSource<MetadataDocument>;
 
   archiveEntityDataSource: IngestDataSource<ArchiveEntity>;
 

--- a/client/src/app/submission/submission.component.ts
+++ b/client/src/app/submission/submission.component.ts
@@ -44,7 +44,6 @@ export class SubmissionComponent implements OnInit, OnDestroy {
   selectedIndex: any = 0;
   validationErrors: any;
 
-  // TODO: Give these a type
   biomaterialsDataSource: MetadataDataSource<MetadataDocument>;
   processesDataSource: MetadataDataSource<MetadataDocument>;
   protocolsDataSource: MetadataDataSource<MetadataDocument>;

--- a/client/src/app/submission/submission.component.ts
+++ b/client/src/app/submission/submission.component.ts
@@ -11,6 +11,7 @@ import {BrokerService} from '../shared/services/broker.service';
 import {Project} from '../shared/models/project';
 import {ArchiveEntity} from '../shared/models/archiveEntity';
 import {IngestDataSource} from '../shared/components/data-table/data-source/ingest-data-source';
+import {MetadataDataSource} from './metadata-data-source';
 
 
 @Component({
@@ -307,10 +308,17 @@ export class SubmissionComponent implements OnInit, OnDestroy {
   }
 
   private initDataSources() {
-    const submissionTypes = ['biomaterials', 'processes', 'protocols', 'files', 'bundleManifests', 'files'];
+    const submissionTypes = ['biomaterials', 'processes', 'protocols', 'files', 'bundleManifests'];
     submissionTypes.forEach(type => {
-      this[`${type}DataSource`] = new IngestDataSource<any>(
-        this.ingestService, this.submissionEnvelope._links[type].href,
+      if (this[`${type}DataSource`]) {
+        // Ensure this is only called once.
+        // datasources should not be reinistatiated
+        // TODO: sort out other polling here and remove this check
+        return;
+      }
+      this[`${type}DataSource`] = new MetadataDataSource<any>(
+        this.ingestService,
+        this.submissionEnvelope._links[type].href,
         type
       );
     });

--- a/client/src/app/submission/submission.component.ts
+++ b/client/src/app/submission/submission.component.ts
@@ -11,7 +11,7 @@ import {BrokerService} from '../shared/services/broker.service';
 import {Project} from '../shared/models/project';
 import {ArchiveEntity} from '../shared/models/archiveEntity';
 import {IngestDataSource} from '../shared/components/data-table/data-source/ingest-data-source';
-import {MetadataDataSource} from './metadata-data-source';
+import {MetadataDataSource, SubmissionDataSource} from './metadata-data-source';
 
 
 @Component({
@@ -316,7 +316,7 @@ export class SubmissionComponent implements OnInit, OnDestroy {
         // TODO: sort out other polling here and remove this check
         return;
       }
-      this[`${type}DataSource`] = new MetadataDataSource<any>(
+      this[`${type}DataSource`] = new SubmissionDataSource<any>(
         (params) => this.ingestService.fetchSubmissionData(this.submissionEnvelopeId, type, params),
         type
       );

--- a/client/src/app/submission/submission.component.ts
+++ b/client/src/app/submission/submission.component.ts
@@ -42,6 +42,13 @@ export class SubmissionComponent implements OnInit, OnDestroy {
   selectedIndex: any = 0;
   validationErrors: any;
 
+  // TODO: Give these a type
+  biomaterialsDataSource: any;
+  processesDataSource: any;
+  protocolsDataSource: any;
+  bundleManifestsDataSource: any;
+  filesDataSource: any;
+
   archiveEntityDataSource: IngestDataSource<ArchiveEntity>;
 
   private alive: boolean;
@@ -217,6 +224,9 @@ export class SubmissionComponent implements OnInit, OnDestroy {
           this.getSubmissionErrors();
           this.getSubmissionManifest();
           this.getValidationSummary();
+
+          // TODO: move this polling into data source
+          this.initDataSources();
         }
       });
   }
@@ -233,7 +243,6 @@ export class SubmissionComponent implements OnInit, OnDestroy {
     if (this.submissionEnvelopeId) {
       this.submissionEnvelope$ = this.ingestService.getSubmission(this.submissionEnvelopeId);
     } else if (this.submissionEnvelopeUuid) {
-
       this.submissionEnvelope$ = this.ingestService.getSubmissionByUuid(this.submissionEnvelopeUuid);
     } else {
       this.submissionEnvelope$ = null;
@@ -293,9 +302,18 @@ export class SubmissionComponent implements OnInit, OnDestroy {
             const entitiesUrl = archiveSubmission['_links']['entities']['href'];
             this.archiveEntityDataSource = new IngestDataSource<ArchiveEntity>(this.ingestService, entitiesUrl, 'archiveEntities');
           }
-
         }
       );
+  }
+
+  private initDataSources() {
+    const submissionTypes = ['biomaterials', 'processes', 'protocols', 'files', 'bundleManifests', 'files'];
+    submissionTypes.forEach(type => {
+      this[`${type}DataSource`] = new IngestDataSource<any>(
+        this.ingestService, this.submissionEnvelope._links[type].href,
+        type
+      );
+    });
   }
 
   private getSubmissionManifest() {

--- a/client/src/app/submission/submission.component.ts
+++ b/client/src/app/submission/submission.component.ts
@@ -76,7 +76,6 @@ export class SubmissionComponent implements OnInit, OnDestroy {
     this.pollEntities();
 
     this.initArchiveEntityDataSource(this.submissionEnvelopeUuid);
-    this.getValidationSummary()
   }
 
   ngOnDestroy() {
@@ -217,6 +216,7 @@ export class SubmissionComponent implements OnInit, OnDestroy {
         if (this.submissionEnvelope) {
           this.getSubmissionErrors();
           this.getSubmissionManifest();
+          this.getValidationSummary();
         }
       });
   }

--- a/client/src/app/submission/submission.component.ts
+++ b/client/src/app/submission/submission.component.ts
@@ -11,7 +11,7 @@ import {BrokerService} from '../shared/services/broker.service';
 import {Project} from '../shared/models/project';
 import {ArchiveEntity} from '../shared/models/archiveEntity';
 import {IngestDataSource} from '../shared/components/data-table/data-source/ingest-data-source';
-import {MetadataDataSource, SubmissionDataSource} from './metadata-data-source';
+import {MetadataDataSource} from './metadata-data-source';
 
 
 @Component({

--- a/client/src/app/submission/submission.component.ts
+++ b/client/src/app/submission/submission.component.ts
@@ -40,7 +40,7 @@ export class SubmissionComponent implements OnInit, OnDestroy {
   manifest: Object;
   submissionErrors: Object[];
   selectedIndex: any = 0;
-  validationErrors: any
+  validationErrors: any;
 
   archiveEntityDataSource: IngestDataSource<ArchiveEntity>;
 
@@ -316,5 +316,9 @@ export class SubmissionComponent implements OnInit, OnDestroy {
             console.error(err);
           }
         });
+  }
+
+  navigateToTab(index: number): void {
+    this.selectedIndex = index;
   }
 }

--- a/client/src/app/submission/submission.component.ts
+++ b/client/src/app/submission/submission.component.ts
@@ -40,6 +40,7 @@ export class SubmissionComponent implements OnInit, OnDestroy {
   manifest: Object;
   submissionErrors: Object[];
   selectedIndex: any = 0;
+  validationErrors: any
 
   archiveEntityDataSource: IngestDataSource<ArchiveEntity>;
 
@@ -75,6 +76,7 @@ export class SubmissionComponent implements OnInit, OnDestroy {
     this.pollEntities();
 
     this.initArchiveEntityDataSource(this.submissionEnvelopeUuid);
+    this.getValidationSummary()
   }
 
   ngOnDestroy() {
@@ -91,6 +93,24 @@ export class SubmissionComponent implements OnInit, OnDestroy {
     this.project$.subscribe(project => {
       this.setProject(project);
     });
+  }
+
+  getValidationSummary() {
+    this.validationErrors = {
+      biomaterials: {
+        total: 4,
+        metadataErrors: 4,
+      },
+      processes: {
+        total: 4,
+        metadataErrors: 4
+      },
+      files: {
+        total: 24,
+        metadataErrors: 4,
+        fileMissing: 20
+      }
+    };
   }
 
   setProject(project) {

--- a/client/src/app/submission/submission.component.ts
+++ b/client/src/app/submission/submission.component.ts
@@ -316,7 +316,7 @@ export class SubmissionComponent implements OnInit, OnDestroy {
         // TODO: sort out other polling here and remove this check
         return;
       }
-      this[`${type}DataSource`] = new SubmissionDataSource<any>(
+      this[`${type}DataSource`] = new MetadataDataSource<any>(
         (params) => this.ingestService.fetchSubmissionData(this.submissionEnvelopeId, type, params),
         type
       );


### PR DESCRIPTION
This PR allows for filtering by file validation error type (invalid metadata, invalid file, file missing) but it also does a fair bit of refactoring to extract data gathering from the component. This separates the concerns a bit and should make it easier to incorporate this into project view when we can.

Here's a breakdown of the changes:

- Created a `PaginatedDataSource`
  - This is responsible for gathering metadata, performing polling, pagination, and sorting
  - This currently sites in the `submission` directory but I think should be moved to `shared` as the logic is reusable.
- Created a `MetadataDataSource`
  - This extends `PaginatedDataSource` and adds filtering by state and file validation state
  - This also currently sits in the `submission` directory but I think should be moved to `shared` and used by project view (@aaclan-ebi and I had some discussion about this in https://github.com/ebi-ait/ingest-ui/pull/68/files)
- Created `shared/constants.ts`
  - This houses the constants for file validation error types as they are used in `IngestService` as well as `MetadataListComponent`. There might be a better way to do this but this is what I came up with
- Updated `fetchSubmissionData` in `IngestService` to use the query endpoint to filter by file validation errors
- Removed all data gathering logic from `MetadataListComponent`
- Fixed the bug where filtering in `MetadataListComponent` would change the page the user is viewing
- Added UI for filtering files to `MetadataListComponent`
- Added some "dummy" functions for when we get the validation summary endpoint

I think that's it - just ask if you spot any other changes that need clarification.

FYI: When we have the summary endpoint we can just revert 78ec88f271eb5665bd59990ecc3867efde18412a


