### PR TITLE
Fix typo that caused organ form element not to show in projects/new

### DIFF
--- a/client/src/app/project-form/layout.ts
+++ b/client/src/app/project-form/layout.ts
@@ -12,7 +12,7 @@ export const layout: MetadataFormLayout = {
         'project.dataAccess',
         'project.identifyingOrganisms',
         'project.technology',
-        'project.organs',
+        'project.organ',
         'project.releaseDate',
         'project.accessionDate',
         'project.content.array_express_accessions',


### PR DESCRIPTION
I didn't realise there were two forms!

Relates to #77 