### PR TITLE
Only send the content object when PATCHing

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -8390,9 +8390,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+      "version": "4.17.20",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
     },
     "lodash.assign": {
       "version": "4.2.0",

--- a/client/package.json
+++ b/client/package.json
@@ -39,6 +39,7 @@
     "ejs": "^2.7.4",
     "file-saver": "^2.0.2",
     "hammerjs": "^2.0.8",
+    "lodash": "^4.17.20",
     "node-sass": "^4.13.1",
     "npm": "^6.14.4",
     "oidc-client": "^1.10.1",

--- a/client/src/app/metadata-details-dialog/metadata-details-dialog.component.html
+++ b/client/src/app/metadata-details-dialog/metadata-details-dialog.component.html
@@ -4,6 +4,13 @@
   <span class="vf-u-text-color--red" title="{{error['message']}}">{{error['absoluteDataPath']}}
     : {{error['message']}}</span><br>
 </ng-container>
+
+<ng-container *ngIf="errorMessage">
+  <br/>
+  <span class="vf-u-text-color--red" title="{{errorMessage}}">{{errorMessage}}</span>
+  <br>
+</ng-container>
+
 <br/>
 <mat-dialog-content>
 

--- a/client/src/app/metadata-details-dialog/metadata-details-dialog.component.ts
+++ b/client/src/app/metadata-details-dialog/metadata-details-dialog.component.ts
@@ -4,14 +4,12 @@ import {MetadataFormLayout, MetadataFormTab} from '../metadata-schema-form/model
 import {ActivatedRoute} from '@angular/router';
 import {IngestService} from '../shared/services/ingest.service';
 import {SchemaService} from '../shared/services/schema.service';
-import {concatMap, map, tap} from 'rxjs/operators';
 import {MAT_DIALOG_DATA, MatDialogRef} from '@angular/material/dialog';
 import {LoaderService} from '../shared/services/loader.service';
 import {MetadataDocument} from '../shared/models/metadata-document';
-import {Observable, of} from 'rxjs';
-import {ListResult} from '../shared/models/hateoas';
 import {MetadataFormComponent} from '../metadata-schema-form/metadata-form/metadata-form.component';
 import {AlertService} from '../shared/services/alert.service';
+import * as _ from 'lodash';
 
 @Component({
   selector: 'app-metadata-details',
@@ -42,6 +40,7 @@ export class MetadataDetailsDialogComponent implements OnInit {
 
   type: string;
   id: string;
+  errorMessage: string;
 
 
   constructor(private route: ActivatedRoute,
@@ -82,34 +81,26 @@ export class MetadataDetailsDialogComponent implements OnInit {
 
   onSave() {
     const formData = this.metadataFormComponent.getFormData();
-    console.log('saving data', formData);
     const selfLink = this.metadata._links['self']['href'];
     const newContent = formData['value'];
-    this.metadata['content'] = newContent;
-    this.ingestService.patch<MetadataDocument>(selfLink, this.metadata)
-      .subscribe(response => {
-        console.log('successful update', response);
-        this.alertService.clear();
-        this.alertService.success('Success',
-          `${this.type} ${this.id} has been successfully updated`);
-        this.dialogRef.close();
-      }, err => {
-        this.alertService.clear();
-        this.alertService.error('Error',
-          `${this.type} ${this.id} has not been updated due to ${err.toString()}`);
-        this.dialogRef.close();
-      });
-
+    if (_.isEqual(this.metadata['content'], newContent)) {
+      this.errorMessage = 'There are no changes done.';
+    } else {
+      this.metadata['content'] = newContent;
+      const patch = {'content': newContent};
+      this.ingestService.patch<MetadataDocument>(selfLink, patch)
+        .subscribe(response => {
+          this.alertService.clear();
+          this.alertService.success('Success',
+            `${this.type} ${this.id} has been successfully updated`);
+          this.dialogRef.close();
+        }, err => {
+          console.error(err);
+          this.alertService.clear();
+          this.alertService.error('Error',
+            `${this.type} ${this.id} has not been updated due to ${err.toString()}`);
+          this.dialogRef.close();
+        });
+    }
   }
-
-  addInput() {
-    // TODO
-    console.log('add input');
-  }
-
-  removeInput(input: MetadataDocument) {
-    // TODO
-    console.log('remove input');
-  }
-
 }

--- a/client/src/app/metadata-details-dialog/metadata-details-dialog.component.ts
+++ b/client/src/app/metadata-details-dialog/metadata-details-dialog.component.ts
@@ -9,7 +9,7 @@ import {LoaderService} from '../shared/services/loader.service';
 import {MetadataDocument} from '../shared/models/metadata-document';
 import {MetadataFormComponent} from '../metadata-schema-form/metadata-form/metadata-form.component';
 import {AlertService} from '../shared/services/alert.service';
-import * as _ from 'lodash';
+import isEqual from 'lodash/isEqual';
 
 @Component({
   selector: 'app-metadata-details',
@@ -83,7 +83,7 @@ export class MetadataDetailsDialogComponent implements OnInit {
     const formData = this.metadataFormComponent.getFormData();
     const selfLink = this.metadata._links['self']['href'];
     const newContent = formData['value'];
-    if (_.isEqual(this.metadata['content'], newContent)) {
+    if (isEqual(this.metadata['content'], newContent)) {
       this.errorMessage = 'There are no changes done.';
     } else {
       this.metadata['content'] = newContent;

--- a/client/src/app/shared/services/ingest.service.ts
+++ b/client/src/app/shared/services/ingest.service.ts
@@ -2,7 +2,7 @@ import {Injectable} from '@angular/core';
 import {HttpClient} from '@angular/common/http';
 import {Observable, of} from 'rxjs';
 import {map} from 'rxjs/operators';
-import * as _ from 'lodash';
+import values from 'lodash/values';
 
 import {ListResult} from '../models/hateoas';
 import {Summary} from '../models/summary';
@@ -258,7 +258,7 @@ export class IngestService {
       .pipe(map(data => {
         const pagedData: PagedData<MetadataDocument> = {data: [], page: undefined};
         if (data._embedded && data._embedded[entityType]) {
-          pagedData.data = _.values(data._embedded[entityType]);
+          pagedData.data = values(data._embedded[entityType]);
           pagedData.data = IngestService.reduceColumnsForBundleManifests(entityType, pagedData.data);
         } else {
           pagedData.data = [];

--- a/client/src/app/submission/metadata-list/metadata-list.component.ts
+++ b/client/src/app/submission/metadata-list/metadata-list.component.ts
@@ -192,22 +192,15 @@ export class MetadataListComponent implements OnInit, OnDestroy {
     this.schemaService.getDereferencedSchema(schemaUrl)
       .subscribe(data => {
         this.loaderService.display(false);
-        console.log('schema', data);
-
-        const dialogRef = this.dialog.open(MetadataDetailsDialogComponent, {
+        this.dialog.open(MetadataDetailsDialogComponent, {
           data: {metadata: metadata, schema: data},
           width: '60%',
           disableClose: true
-        });
-
-        dialogRef.afterClosed().subscribe(result => {
-          console.log('The dialog was closed');
         });
       });
   }
 
   toggleExpandRow(row: object, rowIndex: number) {
-    const metadata = this.metadataList[rowIndex];
     this.table.rowDetail.toggleExpandRow(row);
   }
 }


### PR DESCRIPTION
File metadata can't be updated in the UI. It seems that all other fields are being sent as part of the payload and the PATCH /files/id endpoint is throwing a HTTP 400 (Bad request) error. This is not happening for other metadata types. I need to check how the file metadata json is being serialised vs other metadata in Core. But this change in the UI fixes it.

ebi-ait/dcp-ingest-central#77