### PR TITLE
Added autosave to local storage for project registration

### DIFF
--- a/client/src/app/app.module.ts
+++ b/client/src/app/app.module.ts
@@ -65,6 +65,7 @@ import {MetadataPickerComponent} from './metadata-picker/metadata-picker.compone
 import {NgxChartsModule} from '@swimlane/ngx-charts';
 import {AuthService} from './shared/services/auth.service';
 import {AutofillProjectService} from './project-registration/services/autofill-project.service';
+import {CacheProjectService} from './project-registration/services/cache-project.service';
 
 const BROWSER_LOCALE = navigator.language;
 
@@ -139,7 +140,8 @@ const BROWSER_LOCALE = navigator.language;
     LoaderService,
     FlattenService,
     SchemaService,
-    AutofillProjectService
+    AutofillProjectService,
+    CacheProjectService
   ],
   bootstrap: [AppComponent]
 })

--- a/client/src/app/app.module.ts
+++ b/client/src/app/app.module.ts
@@ -65,7 +65,7 @@ import {MetadataPickerComponent} from './metadata-picker/metadata-picker.compone
 import {NgxChartsModule} from '@swimlane/ngx-charts';
 import {AuthService} from './shared/services/auth.service';
 import {AutofillProjectService} from './project-registration/services/autofill-project.service';
-import {CacheProjectService} from './project-registration/services/cache-project.service';
+import {ProjectCacheService} from './project-registration/services/project-cache.service';
 
 const BROWSER_LOCALE = navigator.language;
 
@@ -141,7 +141,7 @@ const BROWSER_LOCALE = navigator.language;
     FlattenService,
     SchemaService,
     AutofillProjectService,
-    CacheProjectService
+    ProjectCacheService
   ],
   bootstrap: [AppComponent]
 })

--- a/client/src/app/metadata-schema-form/metadata-form/metadata-form.component.ts
+++ b/client/src/app/metadata-schema-form/metadata-form/metadata-form.component.ts
@@ -5,6 +5,7 @@ import {JsonSchema} from '../models/json-schema';
 import {MetadataFormConfig} from '../models/metadata-form-config';
 import {MetadataForm} from '../models/metadata-form';
 import {MetadataFormTab} from '../models/metadata-form-layout';
+import {of} from 'rxjs';
 
 @Component({
   selector: 'app-metadata-form',
@@ -36,6 +37,8 @@ export class MetadataFormComponent implements OnInit {
 
   @Output() tabChange = new EventEmitter<string>();
 
+  @Output() formValueChange = new EventEmitter<object>();
+
   formGroup: FormGroup;
 
   metadataForm: MetadataForm;
@@ -59,6 +62,8 @@ export class MetadataFormComponent implements OnInit {
       this.selectedTabKey = this.visibleTabs[0].key;
     }
     this.done = true;
+
+    this.onFormChange();
   }
 
   lookupTabIndex(tabKey: string): number {
@@ -91,6 +96,9 @@ export class MetadataFormComponent implements OnInit {
     return true;
   }
 
+  onFormChange() {
+    this.formGroup.valueChanges.subscribe( () => this.formValueChange.emit(of(this.getFormData())));
+  }
 
   onSubmit(e) {
     e.preventDefault();

--- a/client/src/app/metadata-schema-form/metadata-form/metadata-form.component.ts
+++ b/client/src/app/metadata-schema-form/metadata-form/metadata-form.component.ts
@@ -5,7 +5,7 @@ import {JsonSchema} from '../models/json-schema';
 import {MetadataFormConfig} from '../models/metadata-form-config';
 import {MetadataForm} from '../models/metadata-form';
 import {MetadataFormTab} from '../models/metadata-form-layout';
-import {of} from 'rxjs';
+import {Observable, of} from 'rxjs';
 
 @Component({
   selector: 'app-metadata-form',
@@ -37,7 +37,7 @@ export class MetadataFormComponent implements OnInit {
 
   @Output() tabChange = new EventEmitter<string>();
 
-  @Output() formValueChange = new EventEmitter<object>();
+  @Output() formValueChange = new EventEmitter<Observable<object>>();
 
   formGroup: FormGroup;
 

--- a/client/src/app/project-registration/autofill-project-form/autofill-project-form.component.html
+++ b/client/src/app/project-registration/autofill-project-form/autofill-project-form.component.html
@@ -23,4 +23,9 @@
   </a>
 </div>
 
-
+<div *ngIf="projectInCache$ | async" class="vf-u-padding__top--xxl">
+  <a class="vf-link"
+  (click)="restoreProject()">
+    Restore your unsaved project
+  </a>
+</div>

--- a/client/src/app/project-registration/autofill-project-form/autofill-project-form.component.ts
+++ b/client/src/app/project-registration/autofill-project-form/autofill-project-form.component.ts
@@ -24,13 +24,13 @@ export class AutofillProjectFormComponent implements OnInit {
               private router: Router,
               private ingestService: IngestService,
               private alertService: AlertService,
-              private cacheProjectService: ProjectCacheService
+              private projectCacheService: ProjectCacheService
   ) {
   }
 
   ngOnInit(): void {
     this.publicationDoiCtrl = new FormControl('', Validators.required);
-    this.projectInCache$ = this.cacheProjectService.getProject();
+    this.projectInCache$ = this.projectCacheService.getProject();
   }
 
   showError(control: FormControl): string {

--- a/client/src/app/project-registration/autofill-project-form/autofill-project-form.component.ts
+++ b/client/src/app/project-registration/autofill-project-form/autofill-project-form.component.ts
@@ -7,6 +7,7 @@ import {Observable} from 'rxjs';
 import {map} from 'rxjs/operators';
 import {IngestService} from '../../shared/services/ingest.service';
 import {CacheProjectService} from '../services/cache-project.service';
+import {Project} from '../../shared/models/project';
 
 @Component({
   selector: 'app-doi-name-field',
@@ -17,7 +18,7 @@ import {CacheProjectService} from '../services/cache-project.service';
 
 export class AutofillProjectFormComponent implements OnInit {
   publicationDoiCtrl: FormControl;
-  projectInCache$: Observable<any>;
+  projectInCache$: Observable<Project>;
 
   constructor(private route: ActivatedRoute,
               private router: Router,

--- a/client/src/app/project-registration/autofill-project-form/autofill-project-form.component.ts
+++ b/client/src/app/project-registration/autofill-project-form/autofill-project-form.component.ts
@@ -6,7 +6,7 @@ import {Identifier} from '../models/europe-pmc-search';
 import {Observable} from 'rxjs';
 import {map} from 'rxjs/operators';
 import {IngestService} from '../../shared/services/ingest.service';
-import {CacheProjectService} from '../services/cache-project.service';
+import {ProjectCacheService} from '../services/project-cache.service';
 import {Project} from '../../shared/models/project';
 
 @Component({
@@ -24,7 +24,7 @@ export class AutofillProjectFormComponent implements OnInit {
               private router: Router,
               private ingestService: IngestService,
               private alertService: AlertService,
-              private cacheProjectService: CacheProjectService
+              private cacheProjectService: ProjectCacheService
   ) {
   }
 

--- a/client/src/app/project-registration/autofill-project-form/autofill-project-form.component.ts
+++ b/client/src/app/project-registration/autofill-project-form/autofill-project-form.component.ts
@@ -6,6 +6,7 @@ import {Identifier} from '../models/europe-pmc-search';
 import {Observable} from 'rxjs';
 import {map} from 'rxjs/operators';
 import {IngestService} from '../../shared/services/ingest.service';
+import {CacheProjectService} from '../services/cache-project.service';
 
 @Component({
   selector: 'app-doi-name-field',
@@ -16,16 +17,19 @@ import {IngestService} from '../../shared/services/ingest.service';
 
 export class AutofillProjectFormComponent implements OnInit {
   publicationDoiCtrl: FormControl;
+  projectInCache$: Observable<any>;
 
   constructor(private route: ActivatedRoute,
               private router: Router,
               private ingestService: IngestService,
-              private alertService: AlertService
+              private alertService: AlertService,
+              private cacheProjectService: CacheProjectService
   ) {
   }
 
   ngOnInit(): void {
     this.publicationDoiCtrl = new FormControl('', Validators.required);
+    this.projectInCache$ = this.cacheProjectService.getProject();
   }
 
   showError(control: FormControl): string {
@@ -73,4 +77,10 @@ export class AutofillProjectFormComponent implements OnInit {
     return this.ingestService.queryProjects(query).pipe(map(data => !!data.page.totalElements));
   }
 
+  restoreProject() {
+    const params = {
+      restore: 'true'
+    };
+    this.router.navigate(['/projects', 'new'], {queryParams: params});
+  }
 }

--- a/client/src/app/project-registration/project-registration-form/project-registration-form.component.html
+++ b/client/src/app/project-registration/project-registration-form/project-registration-form.component.html
@@ -12,7 +12,7 @@
                          [schema]="projectIngestSchema"
                          [data]="projectFormData"
                          [config]="config"
-                         [selectedTabKey]="projectFormTabKey"
+                         [selectedTabKey]="getCurrentTab()"
                          (cancel)="onCancel($event)"
                          (back)="decrementProjectTab()"
                          (tabChange)="onTabChange($event)"

--- a/client/src/app/project-registration/project-registration-form/project-registration-form.component.html
+++ b/client/src/app/project-registration/project-registration-form/project-registration-form.component.html
@@ -17,7 +17,7 @@
                          (back)="decrementProjectTab()"
                          (tabChange)="onTabChange($event)"
                          (save)="onSave($event)"
-                         (formValueChange)="onFormValueChange($event)">
+                         (formValueChange)="saveProjectInCache($event)">
       </app-metadata-form>
     </ng-container>
   </mat-tab>

--- a/client/src/app/project-registration/project-registration-form/project-registration-form.component.html
+++ b/client/src/app/project-registration/project-registration-form/project-registration-form.component.html
@@ -16,7 +16,8 @@
                          (cancel)="onCancel($event)"
                          (back)="decrementProjectTab()"
                          (tabChange)="onTabChange($event)"
-                         (save)="onSave($event)">
+                         (save)="onSave($event)"
+                         (formValueChange)="onFormValueChange($event)">
       </app-metadata-form>
     </ng-container>
   </mat-tab>

--- a/client/src/app/project-registration/project-registration-form/project-registration-form.component.ts
+++ b/client/src/app/project-registration/project-registration-form/project-registration-form.component.ts
@@ -61,7 +61,7 @@ export class ProjectRegistrationFormComponent implements OnInit, OnDestroy {
 
   ngOnInit() {
     const queryParam = this.route.snapshot.queryParamMap;
-    this.setFormData(queryParam);
+    this.loadProjectData(queryParam);
     this.projectIngestSchema['properties']['content'] = this.projectMetadataSchema;
     this.setFormConfig();
     this.projectFormTabKey = this.config.layout.tabs[0].key;
@@ -70,7 +70,7 @@ export class ProjectRegistrationFormComponent implements OnInit, OnDestroy {
     this.ingestService.getUserAccount().subscribe(account => this.userIsWrangler = account.isWrangler());
   }
 
-  setFormData(args: ParamMap) {
+  loadProjectData(args: ParamMap) {
     const emptyProject = {content: {}};
     this.projectFormData$ = of(emptyProject);
 

--- a/client/src/app/project-registration/project-registration-form/project-registration-form.component.ts
+++ b/client/src/app/project-registration/project-registration-form/project-registration-form.component.ts
@@ -15,7 +15,7 @@ import {concatMap, delay, map, takeUntil} from 'rxjs/operators';
 import {AutofillProjectService} from '../services/autofill-project.service';
 import {Identifier} from '../models/europe-pmc-search';
 import {AutofillProject} from '../models/autofill-project';
-import {CacheProjectService} from '../services/cache-project.service';
+import {ProjectCacheService} from '../services/project-cache.service';
 import {environment} from '../../../environments/environment';
 
 @Component({
@@ -57,7 +57,7 @@ export class ProjectRegistrationFormComponent implements OnInit, OnDestroy {
               private loaderService: LoaderService,
               private schemaService: SchemaService,
               private autofillProjectService: AutofillProjectService,
-              private cacheProjectService: CacheProjectService
+              private cacheProjectService: ProjectCacheService
   ) {
   }
 

--- a/client/src/app/project-registration/project-registration-form/project-registration-form.component.ts
+++ b/client/src/app/project-registration/project-registration-form/project-registration-form.component.ts
@@ -11,7 +11,7 @@ import {LoaderService} from '../../shared/services/loader.service';
 import {SchemaService} from '../../shared/services/schema.service';
 import {projectRegLayout} from './project-reg-layout';
 import {Observable, of, Subject} from 'rxjs';
-import {concatMap, delay, distinctUntilChanged, map, takeUntil} from 'rxjs/operators';
+import {concatMap, delay, map, takeUntil} from 'rxjs/operators';
 import {AutofillProjectService} from '../services/autofill-project.service';
 import {Identifier} from '../models/europe-pmc-search';
 import {AutofillProject} from '../models/autofill-project';
@@ -235,11 +235,9 @@ export class ProjectRegistrationFormComponent implements OnInit, OnDestroy {
       );
   }
 
-  // todo: finalise the way timing works here
   onFormValueChange(formData: Observable<object>) {
     formData.pipe(
-      delay(10000), // 10 second
-      distinctUntilChanged(), // todo: do we need this here?s
+      delay(10000), // 10 seconds
       takeUntil(this.unsubscribe)
     ).subscribe(
       (formValue) => {

--- a/client/src/app/project-registration/project-registration-form/project-registration-form.component.ts
+++ b/client/src/app/project-registration/project-registration-form/project-registration-form.component.ts
@@ -251,7 +251,7 @@ export class ProjectRegistrationFormComponent implements OnInit, OnDestroy {
     this.unsubscribe.next();
   }
 
-  loadProjectFromCache() {
+  loadProjectFromCache(): Observable<Project> {
     console.log('fetching project from cache');
     return this.cacheProjectService.getProject();
   }

--- a/client/src/app/project-registration/project-registration-form/project-registration-form.component.ts
+++ b/client/src/app/project-registration/project-registration-form/project-registration-form.component.ts
@@ -55,7 +55,7 @@ export class ProjectRegistrationFormComponent implements OnInit, OnDestroy {
               private loaderService: LoaderService,
               private schemaService: SchemaService,
               private autofillProjectService: AutofillProjectService,
-              private cacheProjectService: ProjectCacheService
+              private projectCacheService: ProjectCacheService
   ) {
   }
 
@@ -77,7 +77,7 @@ export class ProjectRegistrationFormComponent implements OnInit, OnDestroy {
     if (args.has(Identifier.DOI)) {
       this.projectFormData$ = this.autofillProjectDetails(Identifier.DOI, args.get(Identifier.DOI));
     } else if (args.has('restore')) {
-      this.cacheProjectService.getProject().subscribe(() =>
+      this.projectCacheService.getProject().subscribe(() =>
         this.projectFormData$ = this.loadProjectFromCache());
     }
 
@@ -170,7 +170,7 @@ export class ProjectRegistrationFormComponent implements OnInit, OnDestroy {
     ).subscribe(
       (formValue) => {
         console.log('cached project to local storage');
-        this.cacheProjectService.saveProject(formValue['value']);
+        this.projectCacheService.saveProject(formValue['value']);
       }
     );
   }
@@ -181,7 +181,7 @@ export class ProjectRegistrationFormComponent implements OnInit, OnDestroy {
 
   loadProjectFromCache(): Observable<Project> {
     console.log('fetching project from cache');
-    return this.cacheProjectService.getProject();
+    return this.projectCacheService.getProject();
   }
 
   private autofillProjectDetails(id, search): Observable<object> {
@@ -236,7 +236,7 @@ export class ProjectRegistrationFormComponent implements OnInit, OnDestroy {
     this.createProject(formValue).subscribe(project => {
         console.log('Project saved', project);
         this.loaderService.display(false);
-        this.cacheProjectService.removeProject();
+        this.projectCacheService.removeProject();
         this.router.navigate(['projects', 'detail'], {
           queryParams: {
             uuid: project.uuid.uuid,

--- a/client/src/app/project-registration/project-registration-form/project-registration-form.component.ts
+++ b/client/src/app/project-registration/project-registration-form/project-registration-form.component.ts
@@ -62,11 +62,10 @@ export class ProjectRegistrationFormComponent implements OnInit, OnDestroy {
   ngOnInit() {
     const queryParam = this.route.snapshot.queryParamMap;
     this.loadProjectData(queryParam);
-    this.projectIngestSchema['properties']['content'] = this.projectMetadataSchema;
     this.setFormConfig();
-    this.projectFormTabKey = this.config.layout.tabs[0].key;
-
+    this.setCurrentTab(this.getFormConfig().layout.tabs[0].key);
     this.title = 'New Project';
+    this.projectIngestSchema['properties']['content'] = this.projectMetadataSchema;
     this.ingestService.getUserAccount().subscribe(account => this.userIsWrangler = account.isWrangler());
   }
 
@@ -116,6 +115,18 @@ export class ProjectRegistrationFormComponent implements OnInit, OnDestroy {
     };
   }
 
+  getFormConfig(): MetadataFormConfig {
+    return this.config;
+  }
+
+  setCurrentTab(tab: string) {
+    this.projectFormTabKey = tab;
+  }
+
+  getCurrentTab(): string {
+    return this.projectFormTabKey;
+  }
+
   onSave(formData: object) {
     const formValue = formData['value'];
     const valid = formData['valid'];
@@ -140,24 +151,24 @@ export class ProjectRegistrationFormComponent implements OnInit, OnDestroy {
   }
 
   onTabChange($tabKey: string) {
-    this.projectFormTabKey = $tabKey;
+    this.setCurrentTab($tabKey);
   }
 
   incrementProjectTab() {
-    let index = projectRegLayout.tabs.findIndex(tab => tab.key === this.projectFormTabKey);
+    let index = projectRegLayout.tabs.findIndex(tab => tab.key === this.getCurrentTab());
     if (index + 1 < projectRegLayout.tabs.length) {
       index++;
-      this.projectFormTabKey = projectRegLayout.tabs[index].key;
+      this.setCurrentTab(projectRegLayout.tabs[index].key);
       return true;
     }
     return false;
   }
 
   decrementProjectTab() {
-    let index = projectRegLayout.tabs.findIndex(tab => tab.key === this.projectFormTabKey);
+    let index = projectRegLayout.tabs.findIndex(tab => tab.key === this.getCurrentTab());
     if (index > 0) {
       index--;
-      this.projectFormTabKey = projectRegLayout.tabs[index].key;
+      this.setCurrentTab(projectRegLayout.tabs[index].key);
       return true;
     }
     return false;

--- a/client/src/app/project-registration/project-registration-form/project-registration-form.component.ts
+++ b/client/src/app/project-registration/project-registration-form/project-registration-form.component.ts
@@ -16,6 +16,7 @@ import {AutofillProjectService} from '../services/autofill-project.service';
 import {Identifier} from '../models/europe-pmc-search';
 import {AutofillProject} from '../models/autofill-project';
 import {CacheProjectService} from '../services/cache-project.service';
+import {environment} from '../../../environments/environment';
 
 @Component({
   selector: 'app-project-registration-form',
@@ -237,7 +238,7 @@ export class ProjectRegistrationFormComponent implements OnInit, OnDestroy {
 
   onFormValueChange(formData: Observable<object>) {
     formData.pipe(
-      delay(10000), // 10 seconds
+      delay(environment.AUTOSAVE_TIME),
       takeUntil(this.unsubscribe)
     ).subscribe(
       (formValue) => {

--- a/client/src/app/project-registration/project-registration-form/project-registration-form.component.ts
+++ b/client/src/app/project-registration/project-registration-form/project-registration-form.component.ts
@@ -236,7 +236,7 @@ export class ProjectRegistrationFormComponent implements OnInit, OnDestroy {
       );
   }
 
-  onFormValueChange(formData: Observable<object>) {
+  saveProjectInCache(formData: Observable<object>) {
     formData.pipe(
       delay(environment.AUTOSAVE_PERIOD_MILLIS),
       takeUntil(this.unsubscribe)

--- a/client/src/app/project-registration/project-registration-form/project-registration-form.component.ts
+++ b/client/src/app/project-registration/project-registration-form/project-registration-form.component.ts
@@ -238,7 +238,7 @@ export class ProjectRegistrationFormComponent implements OnInit, OnDestroy {
 
   onFormValueChange(formData: Observable<object>) {
     formData.pipe(
-      delay(environment.AUTOSAVE_TIME),
+      delay(environment.AUTOSAVE_PERIOD_MILLIS),
       takeUntil(this.unsubscribe)
     ).subscribe(
       (formValue) => {

--- a/client/src/app/project-registration/services/cache-project.service.ts
+++ b/client/src/app/project-registration/services/cache-project.service.ts
@@ -1,0 +1,31 @@
+import {Injectable} from '@angular/core';
+import {AaiService} from '../../aai/aai.service';
+import {map} from 'rxjs/operators';
+import {Observable} from 'rxjs';
+
+@Injectable()
+export class CacheProjectService {
+
+  constructor(private aai: AaiService) {}
+
+  saveProject(project: object) {
+    this.getProjectKey().subscribe(projectKey => localStorage.setItem(projectKey, JSON.stringify(project)));
+  }
+
+  getProjectKey(): Observable<string> {
+      return this.aai.getUser().pipe(map(user => (user?.profile?.email ?? '') + '-' + 'project'));
+  }
+
+  removeProject() {
+    this.getProjectKey().subscribe(projectKey => localStorage.removeItem(projectKey));
+  }
+
+  getProject(): Observable<object> {
+    return this.getProjectKey().pipe(map(projectKey => JSON.parse(localStorage.getItem(projectKey))));
+  }
+}
+
+
+
+
+

--- a/client/src/app/project-registration/services/cache-project.service.ts
+++ b/client/src/app/project-registration/services/cache-project.service.ts
@@ -2,13 +2,14 @@ import {Injectable} from '@angular/core';
 import {AaiService} from '../../aai/aai.service';
 import {map} from 'rxjs/operators';
 import {Observable} from 'rxjs';
+import {Project} from '../../shared/models/project';
 
 @Injectable()
 export class CacheProjectService {
 
   constructor(private aai: AaiService) {}
 
-  saveProject(project: object) {
+  saveProject(project: Project) {
     this.getProjectKey().subscribe(projectKey => localStorage.setItem(projectKey, JSON.stringify(project)));
   }
 
@@ -20,7 +21,7 @@ export class CacheProjectService {
     this.getProjectKey().subscribe(projectKey => localStorage.removeItem(projectKey));
   }
 
-  getProject(): Observable<object> {
+  getProject(): Observable<Project> {
     return this.getProjectKey().pipe(map(projectKey => JSON.parse(localStorage.getItem(projectKey))));
   }
 }

--- a/client/src/app/project-registration/services/project-cache.service.ts
+++ b/client/src/app/project-registration/services/project-cache.service.ts
@@ -14,7 +14,7 @@ export class ProjectCacheService {
   }
 
   getProjectKey(): Observable<string> {
-      return this.aaiService.getUser().pipe(map(user => (user?.profile?.email ?? '') + '-' + 'project'));
+      return this.aaiService.getUser().pipe(map(user => (`${user?.profile?.email ?? ''}-project`)));
   }
 
   removeProject() {

--- a/client/src/app/project-registration/services/project-cache.service.ts
+++ b/client/src/app/project-registration/services/project-cache.service.ts
@@ -7,14 +7,14 @@ import {Project} from '../../shared/models/project';
 @Injectable()
 export class ProjectCacheService {
 
-  constructor(private aai: AaiService) {}
+  constructor(private aaiService: AaiService) {}
 
   saveProject(project: Project) {
     this.getProjectKey().subscribe(projectKey => localStorage.setItem(projectKey, JSON.stringify(project)));
   }
 
   getProjectKey(): Observable<string> {
-      return this.aai.getUser().pipe(map(user => (user?.profile?.email ?? '') + '-' + 'project'));
+      return this.aaiService.getUser().pipe(map(user => (user?.profile?.email ?? '') + '-' + 'project'));
   }
 
   removeProject() {

--- a/client/src/app/project-registration/services/project-cache.service.ts
+++ b/client/src/app/project-registration/services/project-cache.service.ts
@@ -5,7 +5,7 @@ import {Observable} from 'rxjs';
 import {Project} from '../../shared/models/project';
 
 @Injectable()
-export class CacheProjectService {
+export class ProjectCacheService {
 
   constructor(private aai: AaiService) {}
 

--- a/client/src/environments/environment.dev.ts
+++ b/client/src/environments/environment.dev.ts
@@ -10,5 +10,7 @@ export const environment = {
   AAI_CLIENT_ID: 'e2041c2d-9449-4468-856e-e84711cebd21',
   AAI_AUTHORITY: 'https://login.elixir-czech.org/oidc',
 
-  OLS_URL: 'https://ontology.dev.archive.data.humancellatlas.org'
+  OLS_URL: 'https://ontology.dev.archive.data.humancellatlas.org',
+
+  AUTOSAVE_TIME: 10 * 1000
 };

--- a/client/src/environments/environment.dev.ts
+++ b/client/src/environments/environment.dev.ts
@@ -12,5 +12,5 @@ export const environment = {
 
   OLS_URL: 'https://ontology.dev.archive.data.humancellatlas.org',
 
-  AUTOSAVE_TIME: 10 * 1000
+  AUTOSAVE_PERIOD_MILLIS: 10 * 1000
 };

--- a/client/src/environments/environment.env.ts
+++ b/client/src/environments/environment.env.ts
@@ -12,5 +12,5 @@ export const environment = {
 
   OLS_URL: '<%= OLS_URL %>',
 
-  AUTOSAVE_TIME: 10 * 1000
+  AUTOSAVE_PERIOD_MILLIS: 10 * 1000
 };

--- a/client/src/environments/environment.env.ts
+++ b/client/src/environments/environment.env.ts
@@ -10,5 +10,7 @@ export const environment = {
   AAI_CLIENT_ID: '<%= AAI_CLIENT_ID %>',
   AAI_AUTHORITY: '<%= AAI_AUTHORITY %>',
 
-  OLS_URL: '<%= OLS_URL %>'
+  OLS_URL: '<%= OLS_URL %>',
+
+  AUTOSAVE_TIME: 10 * 1000
 };

--- a/client/src/environments/environment.prod.ts
+++ b/client/src/environments/environment.prod.ts
@@ -10,5 +10,7 @@ export const environment = {
   AAI_CLIENT_ID: 'e2041c2d-9449-4468-856e-e84711cebd21',
   AAI_AUTHORITY: 'https://login.elixir-czech.org/oidc',
 
-  OLS_URL: 'https://ontology.archive.data.humancellatlas.org'
+  OLS_URL: 'https://ontology.archive.data.humancellatlas.org',
+
+  AUTOSAVE_TIME: 10 * 1000
 };

--- a/client/src/environments/environment.prod.ts
+++ b/client/src/environments/environment.prod.ts
@@ -12,5 +12,5 @@ export const environment = {
 
   OLS_URL: 'https://ontology.archive.data.humancellatlas.org',
 
-  AUTOSAVE_TIME: 10 * 1000
+  AUTOSAVE_PERIOD_MILLIS: 10 * 1000
 };

--- a/client/src/environments/environment.staging.ts
+++ b/client/src/environments/environment.staging.ts
@@ -10,5 +10,7 @@ export const environment = {
   AAI_CLIENT_ID: 'e2041c2d-9449-4468-856e-e84711cebd21',
   AAI_AUTHORITY: 'https://login.elixir-czech.org/oidc',
 
-  OLS_URL: 'https://ontology.staging.archive.data.humancellatlas.org'
+  OLS_URL: 'https://ontology.staging.archive.data.humancellatlas.org',
+
+  AUTOSAVE_TIME: 10 * 1000
 };

--- a/client/src/environments/environment.staging.ts
+++ b/client/src/environments/environment.staging.ts
@@ -12,5 +12,5 @@ export const environment = {
 
   OLS_URL: 'https://ontology.staging.archive.data.humancellatlas.org',
 
-  AUTOSAVE_TIME: 10 * 1000
+  AUTOSAVE_PERIOD_MILLIS: 10 * 1000
 };

--- a/client/src/environments/environment.ts
+++ b/client/src/environments/environment.ts
@@ -15,5 +15,7 @@ export const environment = {
   AAI_CLIENT_ID: 'e2041c2d-9449-4468-856e-e84711cebd21',
   AAI_AUTHORITY: 'https://login.elixir-czech.org/oidc',
 
-  OLS_URL: 'https://ontology.dev.archive.data.humancellatlas.org'
+  OLS_URL: 'https://ontology.dev.archive.data.humancellatlas.org',
+
+  AUTOSAVE_TIME: 10 * 1000
 };

--- a/client/src/environments/environment.ts
+++ b/client/src/environments/environment.ts
@@ -17,5 +17,5 @@ export const environment = {
 
   OLS_URL: 'https://ontology.dev.archive.data.humancellatlas.org',
 
-  AUTOSAVE_TIME: 10 * 1000
+  AUTOSAVE_PERIOD_MILLIS: 10 * 1000
 };

--- a/prepare_artifact.sh
+++ b/prepare_artifact.sh
@@ -10,6 +10,8 @@ DOMAIN_WHITELIST=${DOMAIN_WHITELIST:-"localhost:8080,localhost:5000"}
 AAI_CLIENT_ID=${AAI_CLIENT_ID:-"e2041c2d-9449-4468-856e-e84711cebd21"}
 AAI_AUTHORITY=${AAI_AUTHORITY:-"https://login.elixir-czech.org/oidc"}
 OLS_URL=${OLS_URL:-"https://ontology.dev.archive.data.humancellatlas.org"}
+AUTOSAVE_PERIOD_MILLIS=${AUTOSAVE_PERIOD_MILLIS:- 10 * 1000}
+
 
 # Replace template with values in main bundle files
 sed -i "s#<%= INGEST_API_URL %>#$INGEST_API_URL#g" /usr/share/nginx/html/main-*.js
@@ -21,3 +23,4 @@ sed -i "s#<%= SECURED_ENDPOINTS %>#$SECURED_ENDPOINTS#g" /usr/share/nginx/html/m
 sed -i "s#<%= AAI_CLIENT_ID %>#$AAI_CLIENT_ID#g" /usr/share/nginx/html/main-*.js
 sed -i "s#<%= AAI_AUTHORITY %>#$AAI_AUTHORITY#g" /usr/share/nginx/html/main-*.js
 sed -i "s#<%= OLS_URL %>#$OLS_URL#g" /usr/share/nginx/html/main-*.js
+sed -i "s#<%= AUTOSAVE_PERIOD_MILLIS %>#AUTOSAVE_PERIOD_MILLIS#g" /usr/share/nginx/html/main-*.js


### PR DESCRIPTION
While registering a new project, the project will get autosaved to browser local storage every 10 seconds, after every form change by user.

The key for the project will be `{user email address}-project` and the value will be the stringy-fied project object.

This autosaved project in the browser local storage will get deleted when the project gets saved in the ingest db and the option to `restore your unsaved project` will only be available if there is an unsaved project in the local storage