### PR TITLE
ebi-ait/dcp-ingest-central#19: hotfix: revert changes to prepare_artifact.sh

### DIFF
--- a/prepare_artifact.sh
+++ b/prepare_artifact.sh
@@ -10,7 +10,6 @@ DOMAIN_WHITELIST=${DOMAIN_WHITELIST:-"localhost:8080,localhost:5000"}
 AAI_CLIENT_ID=${AAI_CLIENT_ID:-"e2041c2d-9449-4468-856e-e84711cebd21"}
 AAI_AUTHORITY=${AAI_AUTHORITY:-"https://login.elixir-czech.org/oidc"}
 OLS_URL=${OLS_URL:-"https://ontology.dev.archive.data.humancellatlas.org"}
-AUTOSAVE_PERIOD_MILLIS=${AUTOSAVE_PERIOD_MILLIS:- 10 * 1000}
 
 
 # Replace template with values in main bundle files
@@ -23,4 +22,3 @@ sed -i "s#<%= SECURED_ENDPOINTS %>#$SECURED_ENDPOINTS#g" /usr/share/nginx/html/m
 sed -i "s#<%= AAI_CLIENT_ID %>#$AAI_CLIENT_ID#g" /usr/share/nginx/html/main-*.js
 sed -i "s#<%= AAI_AUTHORITY %>#$AAI_AUTHORITY#g" /usr/share/nginx/html/main-*.js
 sed -i "s#<%= OLS_URL %>#$OLS_URL#g" /usr/share/nginx/html/main-*.js
-sed -i "s#<%= AUTOSAVE_PERIOD_MILLIS %>#AUTOSAVE_PERIOD_MILLIS#g" /usr/share/nginx/html/main-*.js


### PR DESCRIPTION
reverting this change: https://github.com/ebi-ait/ingest-ui/pull/89/commits/2ed0cde8ca60e0d011df677f77f64ee52d30bf50, as the autosave timer is constant for all envs