### PR TITLE
The config must be defined before loading metadata form component

### DIFF
--- a/client/src/app/project-form/project-form.component.html
+++ b/client/src/app/project-form/project-form.component.html
@@ -9,7 +9,7 @@
 
 <p *ngIf="!schema || !(projectResource || createMode)">Loading project...</p>
 
-<ng-container *ngIf="schema && (projectResource || createMode) && (userAccount$ | async)">
+<ng-container *ngIf="schema && (projectResource || createMode) && (userAccount$ | async) && config">
   <app-metadata-form name="project"
                      [schema]="projectIngestSchema"
                      [data]="projectFormData"

--- a/client/src/app/project-summary/project-summary.component.html
+++ b/client/src/app/project-summary/project-summary.component.html
@@ -7,7 +7,7 @@
 
 <p *ngIf="!project">Loading project...</p>
 
-<ng-container *ngIf="project && (userAccount$ | async)">
+<ng-container *ngIf="project && (userAccount$ | async) && config">
   <p style="margin: 0.5rem 0 2rem 0">General information about your project.</p>
   <app-metadata-form name="project"
                      [schema]="projectIngestSchema"


### PR DESCRIPTION
Changes:
- The `config` variable is created in an async block. We should wait while that variable properly created to be able to use it, otherwise we get an `undefined` value that would cause an error.