### PR TITLE
Show ontology value correctly

### DIFF
--- a/client/src/app/shared/utils.spec.ts
+++ b/client/src/app/shared/utils.spec.ts
@@ -1,0 +1,28 @@
+import Utils from './utils';
+
+
+describe('Utils', () => {
+  it(`should return false for an random text`, () => {
+    const invalidUrl = 'some text that is not a URL';
+
+    expect(Utils.isUrl(invalidUrl)).toEqual(false);
+  });
+
+  it(`should return false for an NCBI Taxon expression`, () => {
+    const invalidUrl = 'NCBITAXON:10090';
+
+    expect(Utils.isUrl(invalidUrl)).toEqual(false);
+  });
+
+  it(`should return false for a number`, () => {
+    const invalidUrl = '42';
+
+    expect(Utils.isUrl(invalidUrl)).toEqual(false);
+  });
+
+  it(`should return true for a valid URL`, () => {
+    const invalidUrl = 'http://example.com';
+
+    expect(Utils.isUrl(invalidUrl)).toEqual(true);
+  });
+});

--- a/client/src/app/shared/utils.spec.ts
+++ b/client/src/app/shared/utils.spec.ts
@@ -20,6 +20,12 @@ describe('Utils', () => {
     expect(Utils.isUrl(invalidUrl)).toEqual(false);
   });
 
+  it(`should return false for a text starting with http but not a valid URL`, () => {
+    const invalidUrl = 'httpsomething';
+
+    expect(Utils.isUrl(invalidUrl)).toEqual(false);
+  });
+
   it(`should return true for a valid URL`, () => {
     const invalidUrl = 'http://example.com';
 

--- a/client/src/app/shared/utils.ts
+++ b/client/src/app/shared/utils.ts
@@ -1,6 +1,9 @@
 export default class Utils {
 
   static isUrl(value: string) {
+    if (!(value.toString().startsWith('http'))) {
+      return false;
+    }
     try {
       const url = new URL(value);
     } catch (_) {

--- a/client/src/app/shared/utils.ts
+++ b/client/src/app/shared/utils.ts
@@ -1,6 +1,6 @@
 export default class Utils {
 
-  static isUrl(value: string) {
+  static isUrl(value: string): boolean {
     if (!(value.toString().startsWith('http'))) {
       return false;
     }


### PR DESCRIPTION
ebi-ait/dcp-ingest-central#353

Changes:
- If the table cell value does not start with `http` then it won't appear as a URL on the screen.