### PR TITLE
Add HCA publication

### DIFF
--- a/client/src/app/metadata-schema-form/custom/vf-input/vf-input.component.html
+++ b/client/src/app/metadata-schema-form/custom/vf-input/vf-input.component.html
@@ -11,7 +11,6 @@
     <ng-template #checkboxInput>
       <input type="checkbox" id="check_{{id}}" [(ngModel)]="value" class="vf-form__checkbox" (change)="change($event)">
       <label *ngIf="label" for="check_{{id}}" class="vf-form__label">{{label}} </label>
-      <app-vf-asterisk *ngIf="!data.disabled" [isRequired]="data.isRequired"></app-vf-asterisk>
     </ng-template>
     <p class="vf-form__helper vf-form__helper--error">{{error}}</p>
   </div>

--- a/client/src/app/metadata-schema-form/custom/vf-input/vf-input.component.ts
+++ b/client/src/app/metadata-schema-form/custom/vf-input/vf-input.component.ts
@@ -86,11 +86,15 @@ export class VfInputComponent implements ControlValueAccessor, OnInit {
 
   registerOnChange(fn: (text: string) => void): void {
     this.onChange = fn;
-    if (this.inputType === 'checkbox' && this.value === undefined && this.isRequired) {
-      // Sets the default value of the checkbox to be false if is not defined
-      this.value = false;
-      this.onChange(false);
+    this.setDefaultValue();
+  }
+
+  setDefaultValue() {
+    if (!(this.inputType === 'checkbox' && this.value === undefined && this.isRequired)) {
+      return;
     }
+    this.value = false;
+    this.onChange(false);
   }
 
   registerOnTouched(fn: () => void): void {

--- a/client/src/app/metadata-schema-form/custom/vf-input/vf-input.component.ts
+++ b/client/src/app/metadata-schema-form/custom/vf-input/vf-input.component.ts
@@ -67,7 +67,7 @@ export class VfInputComponent implements ControlValueAccessor, OnInit {
     'integer': 'number'
   };
 
-  onChange = (text: string) => {
+  onChange = (text: any) => {
   }
 
   onTouched = () => {
@@ -86,6 +86,11 @@ export class VfInputComponent implements ControlValueAccessor, OnInit {
 
   registerOnChange(fn: (text: string) => void): void {
     this.onChange = fn;
+    if (this.inputType === 'checkbox' && this.value === undefined) {
+      // Sets the default value of the checkbox to be false if is not defined
+      this.value = false;
+      this.onChange(false);
+    }
   }
 
   registerOnTouched(fn: () => void): void {

--- a/client/src/app/metadata-schema-form/custom/vf-input/vf-input.component.ts
+++ b/client/src/app/metadata-schema-form/custom/vf-input/vf-input.component.ts
@@ -86,7 +86,7 @@ export class VfInputComponent implements ControlValueAccessor, OnInit {
 
   registerOnChange(fn: (text: string) => void): void {
     this.onChange = fn;
-    if (this.inputType === 'checkbox' && this.value === undefined) {
+    if (this.inputType === 'checkbox' && this.value === undefined && this.isRequired) {
       // Sets the default value of the checkbox to be false if is not defined
       this.value = false;
       this.onChange(false);

--- a/client/src/app/metadata-schema-form/custom/vf-input/vf-input.component.ts
+++ b/client/src/app/metadata-schema-form/custom/vf-input/vf-input.component.ts
@@ -67,7 +67,7 @@ export class VfInputComponent implements ControlValueAccessor, OnInit {
     'integer': 'number'
   };
 
-  onChange = (text: any) => {
+  onChange = (value: any) => {
   }
 
   onTouched = () => {

--- a/client/src/app/metadata-schema-form/models/metadata-form-helper.ts
+++ b/client/src/app/metadata-schema-form/models/metadata-form-helper.ts
@@ -37,7 +37,8 @@ export class MetadataFormHelper {
 
   toFormControl(field: Metadata, data?: any) {
     const state = {value: data, disabled: field && field.isDisabled};
-    const formControl = field && field.isRequired ? new FormControl(state, Validators.required)
+
+    const formControl = field && field.isRequired && !field.isBoolean() ? new FormControl(state, Validators.required)
       : new FormControl(state);
     return formControl;
   }

--- a/client/src/app/metadata-schema-form/models/metadata.ts
+++ b/client/src/app/metadata-schema-form/models/metadata.ts
@@ -61,7 +61,7 @@ export class Metadata {
   }
 
   isBoolean(): boolean {
-    return this.schema.type === 'boolean';
+    return this.schema && this.schema.type === 'boolean';
   }
 
   addChild(key: string) {

--- a/client/src/app/metadata-schema-form/models/metadata.ts
+++ b/client/src/app/metadata-schema-form/models/metadata.ts
@@ -60,6 +60,10 @@ export class Metadata {
     return this.schema.type === 'array' && ['array', 'object'].indexOf(items['type']) < 0;
   }
 
+  isBoolean(): boolean {
+    return this.schema.type === 'boolean';
+  }
+
   addChild(key: string) {
     this.children.push(key);
   }

--- a/client/src/app/project-create-edit/components/project-metadata-form/layout.ts
+++ b/client/src/app/project-create-edit/components/project-metadata-form/layout.ts
@@ -61,7 +61,7 @@ const getFullLayout = () => ({
       items: [
         {
           keys: [
-            'project.content.publications.title'
+            'project.content.publications'
           ],
           component: PublicationFieldGroupComponent
         }

--- a/client/src/app/project-create-edit/components/publication-field-group/publication-field-group.component.ts
+++ b/client/src/app/project-create-edit/components/publication-field-group/publication-field-group.component.ts
@@ -1,5 +1,4 @@
 import {Component, Input, OnInit} from '@angular/core';
-
 import {InputComponent} from '../../../metadata-schema-form/metadata-field-types/input/input.component';
 
 @Component({

--- a/client/src/app/project-create-edit/schemas/project-metadata-schema.json
+++ b/client/src/app/project-create-edit/schemas/project-metadata-schema.json
@@ -396,12 +396,13 @@
       "description": "Publications resulting from this project.",
       "items": {
         "$schema": "http://json-schema.org/draft-07/schema#",
-        "$id": "https://schema.dev.data.humancellatlas.org/module/project/6.0.0/publication",
+        "$id": "https://schema.dev.data.humancellatlas.org/module/project/7.0.0/publication",
         "description": "Information about a journal article, book, web page, or other external available documentation for a project.",
         "additionalProperties": false,
         "required": [
           "authors",
-          "title"
+          "title",
+          "official_hca_publication"
         ],
         "title": "Publication",
         "name": "publication",
@@ -451,6 +452,13 @@
             "type": "string",
             "user_friendly": "Publication URL",
             "example": "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC5667944/"
+          },
+          "official_hca_publication": {
+            "description": "Has the publication been accepted as an official HCA publication, according to the process described in https://www.humancellatlas.org/publications/ ?",
+            "type": "boolean",
+            "user_friendly": "Official HCA Publication",
+            "guidelines": "Should be one of: yes, or no.",
+            "example": "yes; no"
           }
         }
       },

--- a/client/src/app/project-create-edit/schemas/project-metadata-schema.json
+++ b/client/src/app/project-create-edit/schemas/project-metadata-schema.json
@@ -401,8 +401,7 @@
         "additionalProperties": false,
         "required": [
           "authors",
-          "title",
-          "official_hca_publication"
+          "title"
         ],
         "title": "Publication",
         "name": "publication",

--- a/client/src/app/project-create-edit/schemas/project-metadata-schema.json
+++ b/client/src/app/project-create-edit/schemas/project-metadata-schema.json
@@ -457,7 +457,6 @@
             "description": "Has the publication been accepted as an official HCA publication, according to the process described in https://www.humancellatlas.org/publications/ ?",
             "type": "boolean",
             "user_friendly": "Official HCA Publication",
-            "guidelines": "Should be one of: yes, or no.",
             "example": "yes; no"
           }
         }

--- a/client/src/app/project-create-edit/schemas/project-metadata-schema.json
+++ b/client/src/app/project-create-edit/schemas/project-metadata-schema.json
@@ -401,7 +401,8 @@
         "additionalProperties": false,
         "required": [
           "authors",
-          "title"
+          "title",
+          "official_hca_publication"
         ],
         "title": "Publication",
         "name": "publication",


### PR DESCRIPTION
dcp-424 and dcp-430

- Adds official_hca_publication checkbox to the project registration form
- Changes behaviour of boolean inputs:
  - Boolean inputs can be `true`, `false`, or `undefined` (corresponding contributor) or if they're required fields they can only be `true` of `false` (official hca publication)
  - This removes the `isRequired` validator from boolean fields since that will fail if the value is `false`
  - It also removes the required asterisk marker in the UI on boolean fields since all boolean fields can be `false` as well (unticked)
  - If a boolean field is required then it will be set to `false` by default thus never being able to get to `undefined`
  - If a boolean field is not required then it will be `undefined` by default but as soon as it is touched it will only be able to switch between `true` and `false`. This is the previous behaviour