### PR TITLE
Clean publications from form if empty

### DIFF
--- a/client/src/app/metadata-schema-form/metadata-form.service.spec.ts
+++ b/client/src/app/metadata-schema-form/metadata-form.service.spec.ts
@@ -80,7 +80,7 @@ describe('MetadataFormService', () => {
     });
   });
 
-  it('should clean publications if only has official_hca_publication set', () => {
+  describe('cleanFormData when given publications that only have official_hca_publication', () => {
     const testArray = {
       'publications': [{
         'official_hca_publication': true
@@ -89,15 +89,11 @@ describe('MetadataFormService', () => {
       }]
     };
 
-    expect(service.cleanFormData(testArray)).toEqual({});
-
     const testSingle = {
       'publication': {
         'official_hca_publication': false
       }
     };
-
-    expect(service.cleanFormData(testSingle)).toEqual({});
 
     const testNestedArray = {
       'content': {
@@ -109,15 +105,27 @@ describe('MetadataFormService', () => {
       }
     };
 
-    expect(service.cleanFormData(testNestedArray)).toEqual({
-      'content': {
-        'title': 'Test',
-        'biomaterial_core': {}
-      }
+    it('should clean an array of publications', () => {
+      expect(service.cleanFormData(testArray)).toEqual({});
+    });
+
+
+    it('should clean a single publication', () => {
+      expect(service.cleanFormData(testSingle)).toEqual({});
+    });
+
+
+    it('should clean a nested array of publications', () => {
+      expect(service.cleanFormData(testNestedArray)).toEqual({
+        'content': {
+          'title': 'Test',
+          'biomaterial_core': {}
+        }
+      });
     });
   });
 
-  it('should not clean publications that have more than just official_hca_publication', () => {
+  describe('cleanFormData when given publications that have multiple fields', () => {
     const testArray = {
       'publications': [{
         'official_hca_publication': false
@@ -130,21 +138,12 @@ describe('MetadataFormService', () => {
       }]
     };
 
-    expect(service.cleanFormData(testArray)).toEqual({
-      'publications': [
-        testArray['publications'][1],
-        testArray['publications'][2]
-      ]
-    });
-
     const testSingle = {
       'publication': {
         'official_hca_publication': false,
         'Title': '42'
       }
     };
-
-    expect(service.cleanFormData(testSingle)).toEqual(testSingle);
 
     const testNested = {
       'content': {
@@ -156,17 +155,32 @@ describe('MetadataFormService', () => {
       }
     };
 
-    expect(service.cleanFormData(testNested)).toEqual({
-      'content': {
-        'title': 'Zorgon',
-        'biomaterial_core': {
-          ...testSingle
-        },
+    it('should not clean publications in an array', () => {
+      expect(service.cleanFormData(testArray)).toEqual({
         'publications': [
           testArray['publications'][1],
           testArray['publications'][2]
         ]
-      }
+      });
+    });
+
+    it('should not clean a single publication', () => {
+      expect(service.cleanFormData(testSingle)).toEqual(testSingle);
+    });
+
+    it('should not clean a nested publication', () => {
+      expect(service.cleanFormData(testNested)).toEqual({
+        'content': {
+          'title': 'Zorgon',
+          'biomaterial_core': {
+            ...testSingle
+          },
+          'publications': [
+            testArray['publications'][1],
+            testArray['publications'][2]
+          ]
+        }
+      });
     });
   });
 });

--- a/client/src/app/metadata-schema-form/metadata-form.service.spec.ts
+++ b/client/src/app/metadata-schema-form/metadata-form.service.spec.ts
@@ -125,7 +125,7 @@ describe('MetadataFormService', () => {
         'title': 'Test',
         'official_hca_publication': true
       }, {
-        'title': 'Hithhikers guide',
+        'title': 'Hitchhikers guide',
         'authors': ['Douglas Adams'],
       }]
     };

--- a/client/src/app/metadata-schema-form/metadata-form.service.spec.ts
+++ b/client/src/app/metadata-schema-form/metadata-form.service.spec.ts
@@ -79,4 +79,94 @@ describe('MetadataFormService', () => {
       expect(copy).toEqual(expected);
     });
   });
+
+  it('should clean publications if only has official_hca_publication set', () => {
+    const testArray = {
+      'publications': [{
+        'official_hca_publication': true
+      }, {
+        'official_hca_publication': false
+      }]
+    };
+
+    expect(service.cleanFormData(testArray)).toEqual({});
+
+    const testSingle = {
+      'publication': {
+        'official_hca_publication': false
+      }
+    };
+
+    expect(service.cleanFormData(testSingle)).toEqual({});
+
+    const testNestedArray = {
+      'content': {
+        'title': 'Test',
+        'biomaterial_core': {
+          ...testSingle
+        },
+        ...testArray
+      }
+    };
+
+    expect(service.cleanFormData(testNestedArray)).toEqual({
+      'content': {
+        'title': 'Test',
+        'biomaterial_core': {}
+      }
+    });
+  });
+
+  it('should not clean publications that have more than just official_hca_publication', () => {
+    const testArray = {
+      'publications': [{
+        'official_hca_publication': false
+      }, {
+        'title': 'Test',
+        'official_hca_publication': true
+      }, {
+        'title': 'Hithhikers guide',
+        'authors': ['Douglas Adams'],
+      }]
+    };
+
+    expect(service.cleanFormData(testArray)).toEqual({
+      'publications': [
+        testArray['publications'][1],
+        testArray['publications'][2]
+      ]
+    });
+
+    const testSingle = {
+      'publication': {
+        'official_hca_publication': false,
+        'Title': '42'
+      }
+    };
+
+    expect(service.cleanFormData(testSingle)).toEqual(testSingle);
+
+    const testNested = {
+      'content': {
+        'title': 'Zorgon',
+        'biomaterial_core': {
+          ...testSingle
+        },
+        ...testArray
+      }
+    };
+
+    expect(service.cleanFormData(testNested)).toEqual({
+      'content': {
+        'title': 'Zorgon',
+        'biomaterial_core': {
+          ...testSingle
+        },
+        'publications': [
+          testArray['publications'][1],
+          testArray['publications'][2]
+        ]
+      }
+    });
+  });
 });

--- a/client/src/app/metadata-schema-form/metadata-form.service.ts
+++ b/client/src/app/metadata-schema-form/metadata-form.service.ts
@@ -25,7 +25,6 @@ export class MetadataFormService {
     if (!dataCopy) {
       return dataCopy;
     }
-    console.log(dataCopy);
     return this.cleanPublications(dataCopy);
   }
 

--- a/client/src/app/metadata-schema-form/metadata-form.service.ts
+++ b/client/src/app/metadata-schema-form/metadata-form.service.ts
@@ -21,7 +21,38 @@ export class MetadataFormService {
     if (!formData) {
       return formData;
     }
-    return this.copyValues(formData);
+    const dataCopy = this.copyValues(formData);
+    if (!dataCopy) {
+      return dataCopy;
+    }
+    console.log(dataCopy);
+    return this.cleanPublications(dataCopy);
+  }
+
+  cleanPublications(formData: any) {
+    const isEmptyPublication = publication =>
+      Object.keys(publication).length === 1 && Object.keys(publication)[0] === 'official_hca_publication';
+
+    const removeEmptyPublications = key => {
+      if (typeof formData[key] === 'object' && isEmptyPublication(formData[key])) {
+        delete formData[key];
+      }
+      if (Array.isArray(formData[key])) {
+        formData[key] = formData[key].filter(publication => !isEmptyPublication(publication));
+        if (formData[key].length === 0) {
+          delete formData[key];
+        }
+      }
+    };
+
+    Object.keys(formData).forEach(key => {
+      if (key === 'publication' || key === 'publications') {
+        removeEmptyPublications(key);
+      } else if (typeof formData[key] === 'object') {
+        this.cleanPublications(formData[key]);
+      }
+    });
+    return formData;
   }
 
   copyValues(obj: any): object {

--- a/client/src/app/metadata-schema-form/metadata-form.service.ts
+++ b/client/src/app/metadata-schema-form/metadata-form.service.ts
@@ -25,10 +25,12 @@ export class MetadataFormService {
     if (!dataCopy) {
       return dataCopy;
     }
+    console.log(dataCopy);
     return this.cleanPublications(dataCopy);
   }
 
   cleanPublications(formData: any) {
+    // Needed for dcp-458. Removes publications that only have `official_hca_publication` in their content
     const isEmptyPublication = publication =>
       Object.keys(publication).length === 1 && Object.keys(publication)[0] === 'official_hca_publication';
 


### PR DESCRIPTION
dcp-458

Not the most elegant solution but it works.

Deep searches through the form data to find any key that is "publication" or "publications" and removes and publications that only have `official_hca_publication` set. 

In the project registration form, since a publication is by default "added", the user will still have to delete the publication using the controls if they wish to proceed with registering due to the front-end validation. I believe this is desired as in most cases, there will be a publication