### PR TITLE
Add a new validation tab with some instructions

### DIFF
--- a/src/app/submission/submission.component.html
+++ b/src/app/submission/submission.component.html
@@ -189,7 +189,31 @@
       </ng-template>
     </mat-tab>
 
-    <mat-tab label="Submit" [disabled]="!isValid" *ngIf="displaySubmitTab()">
+    <mat-tab
+      label="Validate"
+      [disabled]="submissionState !== 'Valid'"
+      *ngIf="displayValidateAndSubmitTabs()"
+    >
+      <h3 class="vf-u-margin__top--xxl vf-text vf-text-heading--4">Graph Validation</h3>
+
+      <ng-container *ngIf="graphValidationState !== 'Valid'; else graphValid">
+        <p>To finalize the submission please validate using the
+          <a href="https://github.com/ebi-ait/ingest-graph-validator" target="_blank">Ingest Graph Validator</a>
+          to proceed.
+        </p>
+        <p>
+          Graph Validation State: {{graphValidationState}}
+        </p>
+      </ng-container>
+
+      <ng-template #graphValid>
+        <p>
+          You've validated the submission with the graph validator, awesome! You can proceed to the Submit tab.
+        </p>
+      </ng-template>
+    </mat-tab>
+
+    <mat-tab label="Submit" [disabled]="!isValid" *ngIf="displayValidateAndSubmitTabs()">
       <ng-template matTabContent>
         <app-submit
           [project$]="project$"

--- a/src/app/submission/submission.component.ts
+++ b/src/app/submission/submission.component.ts
@@ -61,6 +61,7 @@ export class SubmissionComponent implements OnInit, OnDestroy {
   submissionEnvelope$: Observable<any>;
   submissionEnvelope;
   submissionState: string;
+  graphValidationState: string;
   isValid: boolean;
   isLinkingDone: boolean;
   isSubmitted: boolean;
@@ -172,6 +173,7 @@ export class SubmissionComponent implements OnInit, OnDestroy {
     this.submissionEnvelopeId = SubmissionComponent.getSubmissionId(submissionEnvelope);
     this.isValid = this.checkIfValid(submissionEnvelope);
     this.submissionState = submissionEnvelope['submissionState'];
+    this.graphValidationState = submissionEnvelope['graphValidationState'];
     this.isSubmitted = this.isStateSubmitted(SubmissionState[submissionEnvelope.submissionState]);
     this.submitLink = this.getLink(submissionEnvelope, 'submit');
     this.exportLink = this.getLink(submissionEnvelope, 'export');
@@ -247,7 +249,9 @@ export class SubmissionComponent implements OnInit, OnDestroy {
 
   checkIfValid(submission) {
     const status = submission['submissionState'];
-    return (status === 'Valid' || this.isStateSubmitted(SubmissionState[status]));
+    const graphValidationState = submission['graphValidationState'];
+    const VALID = 'Valid';
+    return ((status === VALID && graphValidationState === VALID) || this.isStateSubmitted(SubmissionState[status]));
   }
 
   setProject(project) {
@@ -388,7 +392,7 @@ export class SubmissionComponent implements OnInit, OnDestroy {
     }
   }
 
-  displaySubmitTab(): boolean {
+  displayValidateAndSubmitTabs(): boolean {
     return [
       SubmissionState.Submitted,
       SubmissionState.Processing,


### PR DESCRIPTION
dcp-503

- Adds a new "validation" tab (see screenshots)
- Validation tab is only enabled when `submissionState` is `Valid`
- Submission tab is only enabled when `submissionState` = `graphValidationState` = `Valid`


How it looks when `graphValidationState` !== `Valid`:
![image](https://user-images.githubusercontent.com/5579270/138891970-40ebc6d5-dafe-4b23-825f-18188a414d07.png)

How it looks when `graphValidationState` === `Valid`:
![image](https://user-images.githubusercontent.com/5579270/138892396-a79498f2-f01d-4d11-818e-005c4e1aaeb9.png)

