### PR TITLE
dcp-535 add requested state

### DIFF
--- a/src/app/submission/submission.component.html
+++ b/src/app/submission/submission.component.html
@@ -199,7 +199,7 @@
       <ng-container *ngIf="graphValidationState !== 'Valid'; else graphValid">
         <p>In order to finalize your submission, you must validate the graph, or the linking between metadata entities.</p>
         <button
-          *ngIf="graphValidationState !== 'Validating'"
+          *ngIf="graphValidationState !== 'Validating' && graphValidationState !== 'Requested'"
           class="vf-button vf-button--primary  vf-button--sm"
           (click)="triggerGraphValidation()"
         >

--- a/src/app/submission/submission.component.ts
+++ b/src/app/submission/submission.component.ts
@@ -423,7 +423,6 @@ export class SubmissionComponent implements OnInit, OnDestroy {
       case 'Requested':
         return 'orange';
       case 'Pending':
-        return 'orange';
       case 'Validating':
         return 'orange';
       default:

--- a/src/app/submission/submission.component.ts
+++ b/src/app/submission/submission.component.ts
@@ -420,6 +420,8 @@ export class SubmissionComponent implements OnInit, OnDestroy {
     switch (graphValidationState) {
       case 'Invalid':
         return '#d9534f';
+      case 'Requested':
+        return 'orange';
       case 'Pending':
         return 'orange';
       case 'Validating':
@@ -434,7 +436,7 @@ export class SubmissionComponent implements OnInit, OnDestroy {
     this.ingestService.post(url, {}).subscribe(
       (submissionEnvelope) => {
         // Pre-emptively set the validation state
-        this.graphValidationState = 'Validating';
+        this.graphValidationState = 'Requested';
       },
       err => {
         // Pre-emptively set the validation state

--- a/src/app/submission/submission.component.ts
+++ b/src/app/submission/submission.component.ts
@@ -421,7 +421,6 @@ export class SubmissionComponent implements OnInit, OnDestroy {
       case 'Invalid':
         return '#d9534f';
       case 'Requested':
-        return 'orange';
       case 'Pending':
       case 'Validating':
         return 'orange';


### PR DESCRIPTION
dcp-535

- Adds a "Requested" state
- User cannot request another graph validation while in "Requested" state
- Fixes bug where UI would go from "Pending" -> "Validating" -> "Pending" -> "Validating"