### PR TITLE
Dcp 578

### DIFF
--- a/src/app/shared/constants.ts
+++ b/src/app/shared/constants.ts
@@ -33,7 +33,8 @@ export enum METADATA_VALIDATION_STATES {
   Draft = 'Draft',
   Validating = 'Validating',
   Valid = 'Valid',
-  Invalid = 'Invalid'
+  Invalid = 'Invalid',
+  GraphInvalid = 'Causes Invalid Graph'
 }
 
 export enum INVALID_FILE_TYPES {

--- a/src/app/shared/models/fetch-submission-data-options.ts
+++ b/src/app/shared/models/fetch-submission-data-options.ts
@@ -1,0 +1,9 @@
+import {INVALID_FILE_TYPES, METADATA_VALIDATION_STATES} from "@shared/constants";
+import {Sort} from "@shared/models/paginatedEndpoint";
+
+export interface FetchSubmissionDataOptions {
+  submissionId: string;
+  entityType: string;
+  sort: Sort;
+  filterState: METADATA_VALIDATION_STATES | INVALID_FILE_TYPES;
+}

--- a/src/app/shared/services/ingest.service.ts
+++ b/src/app/shared/services/ingest.service.ts
@@ -1,5 +1,6 @@
 import {HttpClient} from '@angular/common/http';
 import {Injectable} from '@angular/core';
+import {FetchSubmissionDataOptions} from "@shared/models/fetch-submission-data-options";
 import values from 'lodash/values';
 import {Observable} from 'rxjs';
 import {map} from 'rxjs/operators';
@@ -225,54 +226,48 @@ export class IngestService {
       .pipe(map(data => data._embedded && data._embedded.projects ? data._embedded.projects[0] : null));
   }
 
-  public fetchSubmissionData(submissionId, entityType, params): Observable<PagedData<MetadataDocument>> {
-    let url = `${this.API_URL}/submissionEnvelopes/${submissionId}/${entityType}`;
-    const submission_url = `${this.API_URL}/submissionEnvelopes/${submissionId}`;
+  public fetchSubmissionData(options: FetchSubmissionDataOptions): Observable<PagedData<MetadataDocument>> {
+    let url = `${this.API_URL}/submissionEnvelopes/${options.submissionId}/${options.entityType}`;
+    const submission_url = `${this.API_URL}/submissionEnvelopes/${options.submissionId}`;
+    const params = {};
 
-    // THIS IS A MESS. CLEAN IT UP!!!!!
-
-    // IMPORTANT! The order of these if statements matters
-    // The url is overridden in each but params will be preserved.
-    // E.g. params.sort can be added and used in the url for filtering as well
-    // This might not be the best way to do this but with the varying endpoints, it's okay
-    const sort = params['sort'];
-    if (sort) {
-      url = `${this.API_URL}/${entityType}/search/findBySubmissionEnvelope`;
+    // Depending on the options given, a different endpoint is used
+    // This function abstracts away the logic of using different endpoints to filter by different means
+    if (options.sort) {
+      url = `${this.API_URL}/${options.submissionId}/search/findBySubmissionEnvelope`;
       params['envelopeUri'] = encodeURIComponent(submission_url);
-      params['sort'] = `${sort['column']},${sort['direction']}`;
+      params['sort'] = `${options.sort.column},${options.sort.direction}`;
     }
 
-    const humanFriendlyTypes = INVALID_FILE_TYPES_AND_CODES.map(a => a.humanFriendly);
+    const humanFriendlyTypes: string[] = INVALID_FILE_TYPES_AND_CODES.map(a => a.humanFriendly);
 
-    if (params.filterState === METADATA_VALIDATION_STATES.GraphInvalid) {
-      url = `${this.API_URL}/${entityType}/search/findBySubmissionIdWithGraphValidationErrors`;
-      params['envelopeId'] = submissionId;
+    if (options.filterState === METADATA_VALIDATION_STATES.GraphInvalid) {
+      url = `${this.API_URL}/${options.entityType}/search/findBySubmissionIdWithGraphValidationErrors`;
+      params['envelopeId'] = options.submissionId;
+      delete params['envelopeUri']; // Don't need this if has been set
     }
-
-    else if (params.filterState && !humanFriendlyTypes.includes(params.filterState)) {
-      url = `${this.API_URL}/${entityType}/search/findBySubmissionEnvelopeAndValidationState`;
+    else if (options.filterState && !humanFriendlyTypes.includes(options.filterState)) {
+      url = `${this.API_URL}/${options.entityType}/search/findBySubmissionEnvelopeAndValidationState`;
       params['envelopeUri'] = encodeURIComponent(submission_url);
-      params['state'] = params.filterState.toUpperCase();
+      params['state'] = options.filterState.toUpperCase();
     }
-
-    else if (params.filterState && humanFriendlyTypes.includes(params.filterState)) {
-      if (entityType !== 'files') {
+    else if (options.filterState) {
+      if (options.entityType !== 'files') {
         throw new Error('Only files can be filtered by validation type.');
       }
 
       url = `${this.API_URL}/files/search/findBySubmissionEnvelopeIdAndErrorType`;
-      const fileValidationTypeFilter = INVALID_FILE_TYPES_AND_CODES.find(type => type.humanFriendly === params.filterState).code;
-      delete params.filterState; // Don't want to include this in the request
-      params.errorType = fileValidationTypeFilter;
-      params.id = submissionId;
+      const fileValidationTypeFilter = INVALID_FILE_TYPES_AND_CODES.find(type => type.humanFriendly === options.filterState).code;
+      params['errorType'] = fileValidationTypeFilter;
+      params['id'] = options.submissionId;
     }
 
-    return this.http.get<ListResult<MetadataDocument>>(url, {params: params})
+    return this.http.get<ListResult<MetadataDocument>>(url, {params})
       .pipe(map(data => {
         const pagedData: PagedData<MetadataDocument> = {data: [], page: undefined};
-        if (data._embedded && data._embedded[entityType]) {
-          pagedData.data = values(data._embedded[entityType]);
-          pagedData.data = IngestService.reduceColumnsForBundleManifests(entityType, pagedData.data);
+        if (data._embedded && data._embedded[options.entityType]) {
+          pagedData.data = values(data._embedded[options.entityType]);
+          pagedData.data = IngestService.reduceColumnsForBundleManifests(options.entityType, pagedData.data);
         } else {
           pagedData.data = [];
         }

--- a/src/app/submission/components/entity-validation-summary/entity-validation-summary.component.ts
+++ b/src/app/submission/components/entity-validation-summary/entity-validation-summary.component.ts
@@ -1,4 +1,4 @@
-import {Component, EventEmitter, Input, OnInit, Output} from '@angular/core';
+import {Component, EventEmitter, Input, OnChanges, OnInit, Output, SimpleChanges} from '@angular/core';
 import {INVALID_FILE_TYPES, METADATA_VALIDATION_STATES} from "@shared/constants";
 import { startCase, toLower } from 'lodash';
 
@@ -14,7 +14,7 @@ interface Summary {
   templateUrl: './entity-validation-summary.component.html',
   styleUrls: ['./entity-validation-summary.component.scss']
 })
-export class EntityValidationSummaryComponent implements OnInit {
+export class EntityValidationSummaryComponent implements OnInit, OnChanges {
 
   @Input() source: string;
   @Input() summaries: Summary[];
@@ -27,6 +27,14 @@ export class EntityValidationSummaryComponent implements OnInit {
 
   ngOnInit(): void {
     this.title = startCase(toLower(this.source));
+    this.computeTotalInvalid();
+  }
+
+  ngOnChanges(changes:SimpleChanges): void {
+    this.computeTotalInvalid();
+  }
+
+  computeTotalInvalid() {
     this.totalInvalid = this.summaries.reduce((prev, cur) => prev + cur.count, 0)
   }
 

--- a/src/app/submission/components/metadata-list/metadata-list.component.html
+++ b/src/app/submission/components/metadata-list/metadata-list.component.html
@@ -72,12 +72,12 @@
         <ng-container *ngIf="row['validationState'] === METADATA_VALIDATION_STATES.Valid || row['validationState'] === METADATA_VALIDATION_STATES.Invalid">
           <h3>Metadata Validation Report</h3>
           <!--Metadata validation-->
-          <div style="padding-left:35px;" *ngIf="row['validationState'] === 'Invalid'">
+          <div style="padding-left:35px;" *ngIf="row['validationState'] === METADATA_VALIDATION_STATES.Invalid">
             <ng-container *ngFor="let error of getValidationErrors(row)">
               <span class="vf-u-text-color--red" title="{{error}}">{{error}}</span><br>
             </ng-container>
           </div>
-          <div style="padding-left:35px;" *ngIf="row['validationState'] === 'Metadata valid'">
+          <div style="padding-left:35px;" *ngIf="row['validationState'] === METADATA_VALIDATION_STATES.Valid">
             <span class="vf-u-text-color--green">{{getDefaultValidMessage()}}</span>
           </div>
           <!--Graph validation-->

--- a/src/app/submission/components/metadata-list/metadata-list.component.html
+++ b/src/app/submission/components/metadata-list/metadata-list.component.html
@@ -128,9 +128,9 @@
     </ngx-datatable-column>
 
     <!--Graph Validation State Column-->
-    <ngx-datatable-column name="graph state" [width]="'130'">
+    <ngx-datatable-column name="causes invalid graph" [width]="'130'">
       <ng-template ngx-datatable-cell-template let-rowIndex="rowIndex" let-value="value" let-row="row">
-        <span *ngIf="getGraphValidationErrors(row).length">Invalid</span>
+        <span *ngIf="getGraphValidationErrors(row).length">Yes</span>
         <span *ngIf="!getGraphValidationErrors(row).length">-</span>
       </ng-template>
     </ngx-datatable-column>

--- a/src/app/submission/pages/submission.component.html
+++ b/src/app/submission/pages/submission.component.html
@@ -134,7 +134,8 @@
         <p>In order to finalize your submission, you must validate the graph, or the linking between metadata entities.</p>
         <button
           *ngIf="submissionState !== SUBMISSION_STATES.GraphValidating && submissionState !== SUBMISSION_STATES.GraphValidationRequested"
-          class="vf-button vf-button--primary  vf-button--sm"
+          class="vf-button {{ graphValidationButtonDisabled ? 'vf-button--tertiary' : 'vf-button--primary' }} vf-button--sm"
+          [disabled]="graphValidationButtonDisabled"
           (click)="triggerGraphValidation()"
         >
           Validate Submission

--- a/src/app/submission/pages/submission.component.ts
+++ b/src/app/submission/pages/submission.component.ts
@@ -25,6 +25,8 @@ enum SubmissionTab {
   FILES = 3
 }
 
+const SUBMISSION_POLL_INTERVAL = 5000;
+
 @Component({
   selector: 'app-submission',
   templateUrl: './submission.component.html',
@@ -54,6 +56,7 @@ export class SubmissionComponent implements OnInit, OnDestroy {
   selectedIndex: any = 0;
   validationSummary: SubmissionSummary;
   isLoading: boolean;
+  graphValidationButtonDisabled = false;
 
   submissionDataSource: SimpleDataSource<SubmissionEnvelope>;
   projectDataSource: SimpleDataSource<Project>;
@@ -100,7 +103,7 @@ export class SubmissionComponent implements OnInit, OnDestroy {
 
   connectSubmissionEnvelope() {
     this.submissionDataSource = new SimpleDataSource<SubmissionEnvelope>(this.submissionEnvelopeEndpoint.bind(this));
-    this.submissionDataSource.connect(true).subscribe(submissionEnvelope => {
+    this.submissionDataSource.connect(true, SUBMISSION_POLL_INTERVAL).subscribe(submissionEnvelope => {
       this.initSubmissionAttributes(submissionEnvelope);
       this.displaySubmissionErrors(submissionEnvelope);
       this.checkFromManifestIfLinkingIsDone(submissionEnvelope);
@@ -414,11 +417,12 @@ export class SubmissionComponent implements OnInit, OnDestroy {
     const url = `${this.submissionEnvelope['_links']['self']['href']}/graphValidationRequestedEvent`
     this.ingestService.put(url, {}).subscribe(
       (submissionEnvelope) => {
-        // Pre-emptively set the validation state
-        this.submissionState = SUBMISSION_STATES.GraphValidationRequested;
+        this.graphValidationButtonDisabled = true;
+        setTimeout(() => this.graphValidationButtonDisabled = false, SUBMISSION_POLL_INTERVAL * 4/3)
       },
       err => {
-        this.alertService.error('An error occurred while triggering validation', err.message)
+        this.alertService.error('An error occurred while triggering validation', err.message);
+        this.graphValidationButtonDisabled = false;
       }
     )
   }

--- a/src/app/submission/pages/submission.component.ts
+++ b/src/app/submission/pages/submission.component.ts
@@ -353,7 +353,12 @@ export class SubmissionComponent implements OnInit, OnDestroy {
         return;
       }
       this[`${type}DataSource`] = new MetadataDataSource<any>(
-        (params) => this.ingestService.fetchSubmissionData(this.submissionEnvelopeId, type, params),
+        (params) => this.ingestService.fetchSubmissionData({
+          submissionId: this.submissionEnvelopeId,
+          entityType: type,
+          filterState: params.filterState,
+          sort: params.sort
+        }),
         type
       );
     });


### PR DESCRIPTION
dcp-578

- Uses new endpoint to allow filtering by those with graph validation errors
- tidies up `fetchSubmissionData` a bit, adding a new `FetchSubmissionDataOptions` interface to make things a bit clearer
- Changes wording to better reflect what it actually means for an entity to have graph validation errors
- Disables the validate button for a few seconds to wait for the submission state to update. Stops the user from clicking the button multiple times