### PR TITLE
DCP 570: Prevent new invalid projects being added to catalogue

### DIFF
--- a/src/app/projects/components/project-metadata-form/project-metadata-form.component.ts
+++ b/src/app/projects/components/project-metadata-form/project-metadata-form.component.ts
@@ -10,7 +10,7 @@ import {IngestService} from '@shared/services/ingest.service';
 import {LoaderService} from '@shared/services/loader.service';
 import {SchemaService} from '@shared/services/schema.service';
 import {Observable, of, Subject} from 'rxjs';
-import {concatMap, map, tap} from 'rxjs/operators';
+import {concatMap, tap} from 'rxjs/operators';
 import * as ingestSchema from '../../schemas/project-ingest-schema.json';
 import {ProjectCacheService} from '../../services/project-cache.service';
 import getLayout from './layout';
@@ -124,7 +124,12 @@ export class ProjectMetadataFormComponent implements OnInit, OnDestroy {
 
   onSave({ valid, validationSkipped, value }) {
     if (!this.incrementProjectTab()) {
-      if (valid || validationSkipped) {
+      if (valid) {
+        this.saveProject(value);
+      } else if (validationSkipped) {
+        if (this.create) {
+          value.isInCatalogue = false;
+        }
         this.saveProject(value);
       } else {
         {
@@ -198,7 +203,6 @@ export class ProjectMetadataFormComponent implements OnInit, OnDestroy {
 
   private saveProject(formValue) {
     this.loaderService.display(true);
-    this.alertService.clear();
     this.createOrUpdateProject(formValue).subscribe(project => {
         console.log('Project saved', project);
         this.loaderService.display(false);

--- a/src/app/projects/components/project-metadata-form/project-metadata-form.component.ts
+++ b/src/app/projects/components/project-metadata-form/project-metadata-form.component.ts
@@ -129,6 +129,7 @@ export class ProjectMetadataFormComponent implements OnInit, OnDestroy {
       } else if (validationSkipped) {
         if (this.create) {
           value.isInCatalogue = false;
+          alert('This invalid project will be saved, but has been removed from the project catalogue.');
         }
         this.saveProject(value);
       } else {


### PR DESCRIPTION
- [x] Set `isInCatalogue` to false when creating an invalid project using the 'Ignore validation errors' option
- [x] Notify the user 'This invalid project will be saved, but has been removed from the project catalogue.'