### PR TITLE
Report error from server

### DIFF
--- a/src/app/shared/components/alert/alert.component.ts
+++ b/src/app/shared/components/alert/alert.component.ts
@@ -17,20 +17,13 @@ export class AlertComponent implements OnInit {
   }
 
   ngOnInit() {
-    this.alertService.getAlert().subscribe((alert: Alert) => {
-      if (!alert) {
-        // clear alerts when an empty alert is received
-        this.alerts = [];
-        return;
-      }
-
-      // add alert to array
-      this.alerts.push(alert);
+    this.alertService.getAlert().subscribe((alerts: Alert[]) => {
+      this.alerts = alerts;
     });
   }
 
   removeAlert(alert: Alert) {
-    this.alerts = this.alerts.filter(x => x !== alert);
+    this.alertService.clearOne(alert.id)
     return false;
   }
 

--- a/src/app/shared/models/alert.ts
+++ b/src/app/shared/models/alert.ts
@@ -3,6 +3,8 @@ export class Alert {
   title: string;
   message: string;
   dismissible: boolean;
+  groupName? : string;
+  id: number;
 }
 
 export enum AlertType {

--- a/src/app/shared/services/alert.service.ts
+++ b/src/app/shared/services/alert.service.ts
@@ -1,11 +1,12 @@
 import {Injectable} from '@angular/core';
 import {NavigationStart, Router} from '@angular/router';
-import {Observable, Subject} from 'rxjs';
+import {BehaviorSubject, Observable, Subject} from 'rxjs';
 import {Alert, AlertType} from '../models/alert';
+import { isNil } from 'lodash';
 
 @Injectable()
 export class AlertService {
-  private subject = new Subject<Alert>();
+  private subject = new BehaviorSubject<Alert[]>([]);
   private keepAfterRouteChange = false;
 
   constructor(private router: Router) {
@@ -27,28 +28,40 @@ export class AlertService {
     return this.subject.asObservable();
   }
 
-  success(title: string, message: string, keepAfterRouteChange = false, dismissible = true) {
-    this.alert(AlertType.Success, title, message, keepAfterRouteChange, dismissible);
+  success(title: string, message: string, keepAfterRouteChange = false, dismissible = true, groupName?: string) {
+    this.alert(AlertType.Success, title, message, keepAfterRouteChange, dismissible, groupName);
   }
 
-  error(title: string, message: string, keepAfterRouteChange = false, dismissible = true) {
-    this.alert(AlertType.Error, title, message, keepAfterRouteChange, dismissible);
+  error(title: string, message: string, keepAfterRouteChange = false, dismissible = true, groupName?: string) {
+    this.alert(AlertType.Error, title, message, keepAfterRouteChange, dismissible, groupName);
   }
 
-  info(title: string, message: string, keepAfterRouteChange = false, dismissible = true) {
-    this.alert(AlertType.Info, title, message, keepAfterRouteChange, dismissible);
+  info(title: string, message: string, keepAfterRouteChange = false, dismissible = true, groupName?: string) {
+    this.alert(AlertType.Info, title, message, keepAfterRouteChange, dismissible, groupName);
   }
 
-  warn(title: string, message: string, keepAfterRouteChange = false, dismissible = true) {
-    this.alert(AlertType.Warning, title, message, keepAfterRouteChange, dismissible);
+  warn(title: string, message: string, keepAfterRouteChange = false, dismissible = true, groupName?: string) {
+    this.alert(AlertType.Warning, title, message, keepAfterRouteChange, dismissible, groupName);
   }
 
-  alert(type: AlertType, title: string, message: string, keepAfterRouteChange = false, dismissible = true) {
+  alert(type: AlertType, title: string, message: string, keepAfterRouteChange = false, dismissible = true, groupName?: string) {
     this.keepAfterRouteChange = keepAfterRouteChange;
-    this.subject.next(<Alert>{ type: type, title: title, message: message, dismissible: dismissible});
+    const curValues = this.subject.getValue();
+    const alerts = [ ...curValues, <Alert>{type, title, message, dismissible, groupName, id: curValues.length }]
+    this.subject.next(alerts);
   }
 
   clear() {
-    this.subject.next(null);
+    this.subject.next([]);
+  }
+
+  clearOne(id: number) {
+    const curValues = this.subject.getValue();
+    this.subject.next(curValues.filter(alert => alert.id !== id))
+  }
+
+  clearGroup(groupName: string) {
+    const curValues = this.subject.getValue();
+    this.subject.next(curValues.filter(alert => alert.groupName !== groupName))
   }
 }

--- a/src/app/shared/services/alert.service.ts
+++ b/src/app/shared/services/alert.service.ts
@@ -1,8 +1,7 @@
 import {Injectable} from '@angular/core';
 import {NavigationStart, Router} from '@angular/router';
-import {BehaviorSubject, Observable, Subject} from 'rxjs';
+import {BehaviorSubject, Observable} from 'rxjs';
 import {Alert, AlertType} from '../models/alert';
-import { isNil } from 'lodash';
 
 @Injectable()
 export class AlertService {

--- a/src/app/submission/components/submit/submit.component.ts
+++ b/src/app/submission/components/submit/submit.component.ts
@@ -81,7 +81,7 @@ export class SubmitComponent implements OnInit {
       },
       err => {
         this.loaderService.display(false);
-        this.alertService.error('An error occurred on submitting your submission envelope.', err.message);
+        this.alertService.error('An error occurred on submitting your submission envelope.', err.error.exceptionMessage,);
       }
     );
   }

--- a/src/app/submission/components/submit/submit.component.ts
+++ b/src/app/submission/components/submit/submit.component.ts
@@ -81,7 +81,7 @@ export class SubmitComponent implements OnInit {
       },
       err => {
         this.loaderService.display(false);
-        this.alertService.error('An error occurred on submitting your submission envelope.', err.message, true);
+        this.alertService.error('An error occurred on submitting your submission envelope.', err.message);
       }
     );
   }

--- a/src/app/submission/components/submit/submit.component.ts
+++ b/src/app/submission/components/submit/submit.component.ts
@@ -81,7 +81,7 @@ export class SubmitComponent implements OnInit {
       },
       err => {
         this.loaderService.display(false);
-        this.alertService.error('An error occurred on submitting your submission envelope.', err.error.exceptionMessage,);
+        this.alertService.error('An error occurred on submitting your submission envelope.', err.error.exceptionMessage);
       }
     );
   }

--- a/src/app/submission/components/submit/submit.component.ts
+++ b/src/app/submission/components/submit/submit.component.ts
@@ -40,7 +40,7 @@ export class SubmitComponent implements OnInit {
   }
 
   ngOnInit() {
-    this.project$.subscribe(project => {
+    this.project$ && this.project$.subscribe(project => {
       this.releaseDate = project.releaseDate;
     });
   }
@@ -81,9 +81,7 @@ export class SubmitComponent implements OnInit {
       },
       err => {
         this.loaderService.display(false);
-        this.alertService.error('', 'An error occurred on submitting your submission envelope.', true);
-        console.log(err);
-
+        this.alertService.error('An error occurred on submitting your submission envelope.', err.message, true);
       }
     );
   }

--- a/src/app/submission/pages/submission.component.spec.ts
+++ b/src/app/submission/pages/submission.component.spec.ts
@@ -23,7 +23,7 @@ describe('SubmissionComponent', () => {
 
   beforeEach(() => {
     ingestSvc = jasmine.createSpyObj('IngestService', ['getUserAccount', 'getArchiveSubmission']);
-    alertSvc = jasmine.createSpyObj('AlertService', ['clear', 'error']);
+    alertSvc = jasmine.createSpyObj('AlertService', ['clear', 'error', 'clearGroup']);
     cookieSvc = jasmine.createSpyObj('CookieService', ['set', 'check', 'delete']);
     loaderSvc = jasmine.createSpyObj('LoaderService', ['display']);
     brokerSvc = jasmine.createSpyObj('BrokerService', ['downloadSpreadsheet']);
@@ -65,7 +65,7 @@ describe('SubmissionComponent', () => {
       submissionComponent.displaySubmissionErrors(submissionEnvelope);
 
       // then
-      expect(alertSvc.clear).toHaveBeenCalledTimes(1);
+      expect(alertSvc.clearGroup).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/src/app/submission/pages/submission.component.ts
+++ b/src/app/submission/pages/submission.component.ts
@@ -15,9 +15,9 @@ import {AlertService} from '@shared/services/alert.service';
 import {BrokerService} from '@shared/services/broker.service';
 import {IngestService} from '@shared/services/ingest.service';
 import {LoaderService} from '@shared/services/loader.service';
-import {Observable, TimeoutError, of} from 'rxjs';
-import {catchError, map, mergeMap} from 'rxjs/operators';
 import {CookieService} from 'ngx-cookie-service';
+import {Observable, of, TimeoutError} from 'rxjs';
+import {catchError, map, mergeMap} from 'rxjs/operators';
 
 enum SubmissionTab {
   BIOMATERIALS = 0,
@@ -133,8 +133,9 @@ export class SubmissionComponent implements OnInit, OnDestroy {
 
   displaySubmissionErrors(submissionEnvelope: SubmissionEnvelope) {
     this.submissionErrors = submissionEnvelope['errors'];
+    const errorGroupName = 'submissionErrors';
     if (this.submissionErrors.length >= 0) {
-      this.alertService.clear();
+      this.alertService.clearGroup(errorGroupName);
     }
     if (this.submissionErrors.length > this.MAX_ERRORS) {
       const link = this.submissionEnvelope._links.submissionEnvelopeErrors.href;
@@ -143,14 +144,15 @@ export class SubmissionComponent implements OnInit, OnDestroy {
         `${this.submissionErrors.length - this.MAX_ERRORS} Other Errors`,
         `${message} <a href="${link}">View all ${this.submissionErrors.length} errors.</a>`,
         false,
-        false);
+        false,
+        errorGroupName);
     }
     let errors_displayed = 0;
     for (const err of this.submissionErrors) {
       if (errors_displayed >= this.MAX_ERRORS) {
         break;
       }
-      this.alertService.error(err['title'], err['detail'], false, false);
+      this.alertService.error(err['title'], err['detail'], false, false, errorGroupName);
       errors_displayed++;
     }
   }


### PR DESCRIPTION
dcp-607

- Reports the error from the server instead of a generic message
- Introduces the concept of "groups" to alerts
  - Problem: Alerts were cleared whenever the submission was polled. This was done to refresh the alerts for submission errors. This also removed the alert that is needed here to report a server error when something goes wrong with submitting.
  - The concept of "groups" allows alerts to be cleared on a group level. The alerts for submission errors are in their own group and cleared independently of any other alerts.
  - This is an entirely backwards compatible new feature and does not change the API for previous alerts
  - Remember this exists now :) Might be useful in other places too