### PR TITLE
DCP 620: Unassign Wrangler

### DIFF
--- a/src/app/metadata-schema-form/metadata-form/metadata-form.component.spec.ts
+++ b/src/app/metadata-schema-form/metadata-form/metadata-form.component.spec.ts
@@ -36,11 +36,8 @@ describe('MetadataFormComponent', () => {
                                  schema = {'name': 'project'} as JsonSchema,
                                  config = {}
                                }: metadataFormDependencies) {
-    if (!config.layout) {
+    if (!config.layout || !config.layout.tabs) {
       config.layout = {tabs: [createTab('tab')]};
-    }
-    if (!config.layout.tabs) {
-      config.layout.tabs = [createTab('tab')];
     }
     const form = {
       key: key,

--- a/src/app/metadata-schema-form/metadata-form/metadata-form.component.spec.ts
+++ b/src/app/metadata-schema-form/metadata-form/metadata-form.component.spec.ts
@@ -149,10 +149,23 @@ describe('MetadataFormComponent', () => {
       {name: 'true', value: {cleanAttributes: true}}
     ].forEach(defaultBehaviourTest);
 
-    it('cleanAttributes false behaviour, send no data to be cleaned', () => {
-      setupCleanAttributesTest({cleanAttributes: false});
+    const falseBehaviourTest = test => {
+      it(`cleanAttributes ${test.name} (false) behaviour, send no data to be cleaned`, () => {
+        setupCleanAttributesTest(test.value);
 
-      expect(metadataFormSvc.cleanFormData).not.toHaveBeenCalled();
+        expect(metadataFormSvc.cleanFormData).not.toHaveBeenCalled();
+      });
+    };
+
+    [
+      {name: 'false', value: {cleanAttributes: false}},
+      {name: 'empty Array', value: {cleanAttributes: []}},
+    ].forEach(falseBehaviourTest);
+
+    it('cleanAttributes array behaviour, send matching attributes to be cleaned', () => {
+      setupCleanAttributesTest({cleanAttributes: ['unsetAttribute', 'setObject']});
+
+      expect(metadataFormSvc.cleanFormData).toHaveBeenCalledWith([cleanTest.unsetAttribute, cleanTest.setObject]);
     });
   });
 });

--- a/src/app/metadata-schema-form/metadata-form/metadata-form.component.spec.ts
+++ b/src/app/metadata-schema-form/metadata-form/metadata-form.component.spec.ts
@@ -126,7 +126,7 @@ describe('MetadataFormComponent', () => {
     });
 
     const defaultBehaviourTest = test => {
-      it(`cleanAttributes ${test.name} (default) behaviour: should send all data to be cleaned`, () => {
+      it(`cleanFields ${test.name} (default) behaviour: should send all data to be cleaned`, () => {
         // Given
         configureFormAndSvc({config: test.case});
         fixture.detectChanges();
@@ -141,12 +141,12 @@ describe('MetadataFormComponent', () => {
 
     [
       {name: 'undefined', case: {}},
-      {name: 'null', case: {cleanAttributes: null}},
-      {name: 'true', case: {cleanAttributes: true}}
+      {name: 'null', case: {cleanFields: null}},
+      {name: 'true', case: {cleanFields: true}}
     ].forEach(defaultBehaviourTest);
 
     const falseBehaviourTest = test => {
-      it(`cleanAttributes ${test.name} (false) behaviour, should send no data to be cleaned`, () => {
+      it(`cleanFields ${test.name} (false) behaviour, should send no data to be cleaned`, () => {
         // Given
         configureFormAndSvc({config: test.case});
         fixture.detectChanges();
@@ -160,15 +160,15 @@ describe('MetadataFormComponent', () => {
     };
 
     [
-      {name: 'false', case: {cleanAttributes: false}},
-      {name: 'empty Array', case: {cleanAttributes: []}},
+      {name: 'false', case: {cleanFields: false}},
+      {name: 'empty Array', case: {cleanFields: []}},
     ].forEach(falseBehaviourTest);
 
-    it('cleanAttributes array behaviour, should send matching attributes to be cleaned', () => {
+    it('cleanFields array behaviour, should send matching attributes to be cleaned', () => {
       // Given
       const unsetAttribute = cleanTest.unsetAttribute;
       const setObject = cleanTest.setObject;
-      const testCase = {cleanAttributes: ['unsetAttribute', 'setObject']};
+      const testCase = {cleanFields: ['unsetAttribute', 'setObject']};
       configureFormAndSvc({config: testCase});
       fixture.detectChanges();
 
@@ -180,9 +180,9 @@ describe('MetadataFormComponent', () => {
       expect(metadataFormSvc.cleanFormData).toHaveBeenCalledWith(setObject);
     });
 
-    it('cleanAttributes array behaviour, should only send attributes to be cleaned if they exist', () => {
+    it('cleanFields array behaviour, should only send attributes to be cleaned if they exist', () => {
       // Given
-      const testCase = {cleanAttributes: ['missingAttribute', 'unsetAttribute']};
+      const testCase = {cleanFields: ['missingAttribute', 'unsetAttribute']};
       const unsetAttribute = cleanTest.unsetAttribute;
       configureFormAndSvc({config: testCase});
       fixture.detectChanges();

--- a/src/app/metadata-schema-form/metadata-form/metadata-form.component.spec.ts
+++ b/src/app/metadata-schema-form/metadata-form/metadata-form.component.spec.ts
@@ -144,7 +144,7 @@ describe('MetadataFormComponent', () => {
     };
 
     [
-      {name: 'missing', value: {}},
+      {name: 'undefined', value: {}},
       {name: 'null', value: {cleanAttributes: null}},
       {name: 'true', value: {cleanAttributes: true}}
     ].forEach(defaultBehaviourTest);

--- a/src/app/metadata-schema-form/metadata-form/metadata-form.component.spec.ts
+++ b/src/app/metadata-schema-form/metadata-form/metadata-form.component.spec.ts
@@ -1,104 +1,106 @@
-import {async, ComponentFixture, TestBed} from '@angular/core/testing';
-import {FormControl, FormGroup, Validators} from '@angular/forms';
+import {ComponentFixture, TestBed} from '@angular/core/testing';
 import {MetadataFormService} from '../metadata-form.service';
 import {JsonSchema} from '../models/json-schema';
 import {MetadataForm} from '../models/metadata-form';
 import {MetadataFormConfig} from '../models/metadata-form-config';
 import {MetadataFormTab} from '../models/metadata-form-layout';
 import {MetadataFormComponent} from './metadata-form.component';
-import SpyObj = jasmine.SpyObj;
-
-function getSchema() {
-  return {
-    'name': 'project'
-  } as JsonSchema;
-}
-
-function getData() {
-  return {
-    content: null,
-    admin: {
-      key: 'value'
-    }
-  };
-}
-
-function createTab(title) {
-  return {
-    title: title,
-    key: 'project.' + title,
-    items: [
-      'project.' + title
-    ]
-  } as MetadataFormTab;
-}
-
-function createMetadataFormConfig(tabs: MetadataFormTab[]) {
-  return {
-    viewMode: true,
-    hideEmptyFields: true,
-    layout: {
-      tabs: tabs
-    }
-  } as MetadataFormConfig;
-}
-
-function createFormGroup() {
-  return new FormGroup({
-    x: new FormControl('', Validators.required),
-    y: new FormControl('', Validators.required),
-    z: new FormControl('', Validators.required),
-  });
-}
-
-function createMetadataForm(tabs: MetadataFormTab[]): MetadataForm {
-  return {
-    key: 'test key',
-    jsonSchema: getSchema(),
-    config: createMetadataFormConfig(tabs),
-    metadataRegistry: jasmine.createSpyObj('MetadataRegistry', ['buildMetadataRegistry']),
-    formGroup: createFormGroup()
-  } as MetadataForm;
-}
 
 describe('MetadataFormComponent', () => {
   let component: MetadataFormComponent;
   let fixture: ComponentFixture<MetadataFormComponent>;
 
-  let metadataFormSvc: SpyObj<MetadataFormService>;
+  const metadataFormSvc = jasmine.createSpyObj('MetadataFormService', ['createForm', 'cleanFormData']);
+  const metadataRegistrySpy = jasmine.createSpyObj('MetadataRegistry', ['buildMetadataRegistry']);
+  const formGroupSpy = jasmine.createSpyObj('FormGroup', ['getRawValue', 'valueChanges'], ['valid']);
 
-  const contentTab = createTab('content.contributors');
-  const adminTab = createTab('admin');
-  const tabs = [contentTab, adminTab];
+  interface metadataFormDependencies {
+    key?: string;
+    schema?: JsonSchema;
+    config?: MetadataFormConfig;
+  }
 
-  beforeEach(async(() => {
-    metadataFormSvc = jasmine.createSpyObj('MetadataFormService', ['createForm']);
-    metadataFormSvc.createForm.and.returnValue(createMetadataForm(tabs));
-    TestBed.configureTestingModule({
-      providers: [
-        { provide: MetadataFormService, useValue: metadataFormSvc},
-      ],
-      declarations: [MetadataFormComponent]
-    })
-      .compileComponents();
-  }));
+  function createTab(title) {
+    return {
+      title: title,
+      key: 'project.' + title,
+      items: [
+        'project.' + title
+      ]
+    } as MetadataFormTab;
+  }
+
+  function configureFormAndSvc({
+                                 key = 'test key',
+                                 schema = {'name': 'project'} as JsonSchema,
+                                 config = {layout: {tabs: [createTab('tab')]}}
+                               }: metadataFormDependencies) {
+    const form = {
+      key: key,
+      jsonSchema: schema as JsonSchema,
+      config: config,
+      metadataRegistry: metadataRegistrySpy,
+      formGroup: formGroupSpy
+    } as MetadataForm;
+    metadataFormSvc.createForm.and.returnValue(form);
+    component.form = form;
+    component.formGroup = formGroupSpy;
+    component.schema = schema;
+    component.config = config;
+  }
 
   beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        {provide: MetadataFormService, useValue: metadataFormSvc},
+      ],
+      declarations: [MetadataFormComponent]
+    }).compileComponents();
     fixture = TestBed.createComponent(MetadataFormComponent);
     component = fixture.componentInstance;
-    component.schema = getSchema();
-    component.data = getData();
-    component.config = createMetadataFormConfig(tabs);
-    component.selectedTabKey = 'content';
-    component.visibleTabs = tabs;
-    fixture.detectChanges();
+    spyOn(component, 'onFormChange');
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
   });
 
-  it('tabIsVisible should pass with null content', () => {
-    expect(component.tabIsVisible(contentTab)).toBe(false);
+  describe('tab tests', () => {
+    const contentTab = createTab('content.contributors');
+    const adminTab = createTab('admin');
+    const tabs = [contentTab, adminTab];
+
+    const config = {
+      viewMode: true,
+      hideEmptyFields: true,
+      layout: {
+        tabs: tabs
+      }
+    } as MetadataFormConfig;
+
+    const schema = {
+      'name': 'project'
+    } as JsonSchema;
+
+    const data = {
+      content: null,
+      admin: {
+        key: 'value'
+      }
+    };
+
+    beforeEach(() => {
+      configureFormAndSvc({schema: schema, config: config});
+      component.schema = schema;
+      component.data = data;
+      component.config = config;
+      component.selectedTabKey = 'content';
+      component.visibleTabs = tabs;
+      fixture.detectChanges();
+    });
+
+    it('tabIsVisible should pass with null content', () => {
+      expect(component.tabIsVisible(contentTab)).toBe(false);
+    });
   });
 });

--- a/src/app/metadata-schema-form/metadata-form/metadata-form.component.spec.ts
+++ b/src/app/metadata-schema-form/metadata-form/metadata-form.component.spec.ts
@@ -103,4 +103,33 @@ describe('MetadataFormComponent', () => {
       expect(component.tabIsVisible(contentTab)).toBe(false);
     });
   });
+
+  describe('cleanFormData tests', () => {
+    const cleanTest = {
+      unsetAttribute: null,
+      setAttribute: 'value',
+      unsetObject: {},
+      setObject: {
+        unsetObjectAttribute: null,
+        setObjectAttribute: 'objectValue'
+      }
+    };
+
+    beforeEach(() => {
+      formGroupSpy.getRawValue.and.returnValue(cleanTest);
+      formGroupSpy.valid = true;
+
+      configureFormAndSvc({});
+      component.data = cleanTest;
+
+      fixture.detectChanges();
+    });
+
+    it('cleanAttributes default behaviour, clean all attributes', () => {
+      component.getFormData();
+
+      expect(metadataFormSvc.cleanFormData).toHaveBeenCalledOnceWith(cleanTest);
+    });
+
+  });
 });

--- a/src/app/metadata-schema-form/metadata-form/metadata-form.component.spec.ts
+++ b/src/app/metadata-schema-form/metadata-form/metadata-form.component.spec.ts
@@ -88,10 +88,6 @@ describe('MetadataFormComponent', () => {
       }
     } as MetadataFormConfig;
 
-    const schema = {
-      'name': 'project'
-    } as JsonSchema;
-
     const data = {
       content: null,
       admin: {
@@ -100,7 +96,8 @@ describe('MetadataFormComponent', () => {
     };
 
     beforeEach(() => {
-      configureFormAndSvc({schema: schema, config: config});
+      configureFormAndSvc({config: config});
+      formGroupSpy.getRawValue.and.returnValue(data);
       component.data = data;
       component.selectedTabKey = 'content';
       component.visibleTabs = tabs;
@@ -125,18 +122,14 @@ describe('MetadataFormComponent', () => {
 
     beforeEach(() => {
       formGroupSpy.getRawValue.and.returnValue(cleanTest);
-    });
-
-    function setupCleanAttributesTest(config: MetadataFormConfig) {
-      configureFormAndSvc({config: config});
       component.data = cleanTest;
-      fixture.detectChanges();
-    }
+    });
 
     const defaultBehaviourTest = test => {
       it(`cleanAttributes ${test.name} (default) behaviour: should send all data to be cleaned`, () => {
         // Given
-        setupCleanAttributesTest(test.value);
+        configureFormAndSvc({config: test.case});
+        fixture.detectChanges();
 
         // When
         component.getFormData();
@@ -147,15 +140,16 @@ describe('MetadataFormComponent', () => {
     };
 
     [
-      {name: 'undefined', value: {}},
-      {name: 'null', value: {cleanAttributes: null}},
-      {name: 'true', value: {cleanAttributes: true}}
+      {name: 'undefined', case: {}},
+      {name: 'null', case: {cleanAttributes: null}},
+      {name: 'true', case: {cleanAttributes: true}}
     ].forEach(defaultBehaviourTest);
 
     const falseBehaviourTest = test => {
       it(`cleanAttributes ${test.name} (false) behaviour, should send no data to be cleaned`, () => {
         // Given
-        setupCleanAttributesTest(test.value);
+        configureFormAndSvc({config: test.case});
+        fixture.detectChanges();
 
         // When
         component.getFormData();
@@ -166,15 +160,17 @@ describe('MetadataFormComponent', () => {
     };
 
     [
-      {name: 'false', value: {cleanAttributes: false}},
-      {name: 'empty Array', value: {cleanAttributes: []}},
+      {name: 'false', case: {cleanAttributes: false}},
+      {name: 'empty Array', case: {cleanAttributes: []}},
     ].forEach(falseBehaviourTest);
 
     it('cleanAttributes array behaviour, should send matching attributes to be cleaned', () => {
       // Given
-      setupCleanAttributesTest({cleanAttributes: ['unsetAttribute', 'setObject']});
       const unsetAttribute = cleanTest.unsetAttribute;
       const setObject = cleanTest.setObject;
+      const testCase = {cleanAttributes: ['unsetAttribute', 'setObject']};
+      configureFormAndSvc({config: testCase});
+      fixture.detectChanges();
 
       // When
       component.getFormData();
@@ -186,8 +182,10 @@ describe('MetadataFormComponent', () => {
 
     it('cleanAttributes array behaviour, should only send attributes to be cleaned if they exist', () => {
       // Given
-      setupCleanAttributesTest({cleanAttributes: ['missingAttribute', 'unsetAttribute']});
+      const testCase = {cleanAttributes: ['missingAttribute', 'unsetAttribute']};
       const unsetAttribute = cleanTest.unsetAttribute;
+      configureFormAndSvc({config: testCase});
+      fixture.detectChanges();
 
       // When
       component.getFormData();

--- a/src/app/metadata-schema-form/metadata-form/metadata-form.component.spec.ts
+++ b/src/app/metadata-schema-form/metadata-form/metadata-form.component.spec.ts
@@ -36,7 +36,7 @@ function createTab(title) {
 function createMetadataFormConfig(tabs: MetadataFormTab[]) {
   return {
     viewMode: true,
-    removeEmptyFields: true,
+    hideEmptyFields: true,
     layout: {
       tabs: tabs
     }

--- a/src/app/metadata-schema-form/metadata-form/metadata-form.component.spec.ts
+++ b/src/app/metadata-schema-form/metadata-form/metadata-form.component.spec.ts
@@ -134,7 +134,7 @@ describe('MetadataFormComponent', () => {
     }
 
     const defaultBehaviourTest = test => {
-      it(`cleanAttributes ${test.name} (default) behaviour: send all data to be cleaned`, () => {
+      it(`cleanAttributes ${test.name} (default) behaviour: should send all data to be cleaned`, () => {
         // Given
         setupCleanAttributesTest(test.value);
 
@@ -153,7 +153,7 @@ describe('MetadataFormComponent', () => {
     ].forEach(defaultBehaviourTest);
 
     const falseBehaviourTest = test => {
-      it(`cleanAttributes ${test.name} (false) behaviour, send no data to be cleaned`, () => {
+      it(`cleanAttributes ${test.name} (false) behaviour, should send no data to be cleaned`, () => {
         // Given
         setupCleanAttributesTest(test.value);
 
@@ -170,7 +170,7 @@ describe('MetadataFormComponent', () => {
       {name: 'empty Array', value: {cleanAttributes: []}},
     ].forEach(falseBehaviourTest);
 
-    it('cleanAttributes array behaviour, send matching attributes to be cleaned', () => {
+    it('cleanAttributes array behaviour, should send matching attributes to be cleaned', () => {
       // Given
       setupCleanAttributesTest({cleanAttributes: ['unsetAttribute', 'setObject']});
       const unsetAttribute = cleanTest.unsetAttribute;
@@ -182,6 +182,18 @@ describe('MetadataFormComponent', () => {
       // Then
       expect(metadataFormSvc.cleanFormData).toHaveBeenCalledWith(unsetAttribute);
       expect(metadataFormSvc.cleanFormData).toHaveBeenCalledWith(setObject);
+    });
+
+    it('cleanAttributes array behaviour, should only send attributes to be cleaned if they exist', () => {
+      // Given
+      setupCleanAttributesTest({cleanAttributes: ['missingAttribute', 'unsetAttribute']});
+      const unsetAttribute = cleanTest.unsetAttribute;
+
+      // When
+      component.getFormData();
+
+      // Then
+      expect(metadataFormSvc.cleanFormData).toHaveBeenCalledOnceWith(unsetAttribute);
     });
   });
 });

--- a/src/app/metadata-schema-form/metadata-form/metadata-form.component.spec.ts
+++ b/src/app/metadata-schema-form/metadata-form/metadata-form.component.spec.ts
@@ -125,73 +125,75 @@ describe('MetadataFormComponent', () => {
       component.data = cleanTest;
     });
 
-    const defaultBehaviourTest = test => {
-      it(`cleanFields ${test.name} (default) behaviour: should send all data to be cleaned`, () => {
-        // Given
-        configureFormAndSvc({config: test.case});
-        fixture.detectChanges();
+    describe('cleanFields default behaviour', () => {
+      [
+        {name: 'undefined', case: {}},
+        {name: 'null', case: {cleanFields: null}},
+        {name: 'true', case: {cleanFields: true}}
+      ].forEach(test => {
+        it(`cleanFields ${test.name}: should send all data to be cleaned`, () => {
+          // Given
+          configureFormAndSvc({config: test.case});
+          fixture.detectChanges();
 
-        // When
-        component.getFormData();
+          // When
+          component.getFormData();
 
-        // Then
-        expect(metadataFormSvc.cleanFormData).toHaveBeenCalledOnceWith(cleanTest);
+          // Then
+          expect(metadataFormSvc.cleanFormData).toHaveBeenCalledOnceWith(cleanTest);
+        });
       });
-    };
-
-    [
-      {name: 'undefined', case: {}},
-      {name: 'null', case: {cleanFields: null}},
-      {name: 'true', case: {cleanFields: true}}
-    ].forEach(defaultBehaviourTest);
-
-    const falseBehaviourTest = test => {
-      it(`cleanFields ${test.name} (false) behaviour, should send no data to be cleaned`, () => {
-        // Given
-        configureFormAndSvc({config: test.case});
-        fixture.detectChanges();
-
-        // When
-        component.getFormData();
-
-        // Then
-        expect(metadataFormSvc.cleanFormData).not.toHaveBeenCalled();
-      });
-    };
-
-    [
-      {name: 'false', case: {cleanFields: false}},
-      {name: 'empty Array', case: {cleanFields: []}},
-    ].forEach(falseBehaviourTest);
-
-    it('cleanFields array behaviour, should send matching attributes to be cleaned', () => {
-      // Given
-      const unsetAttribute = cleanTest.unsetAttribute;
-      const setObject = cleanTest.setObject;
-      const testCase = {cleanFields: ['unsetAttribute', 'setObject']};
-      configureFormAndSvc({config: testCase});
-      fixture.detectChanges();
-
-      // When
-      component.getFormData();
-
-      // Then
-      expect(metadataFormSvc.cleanFormData).toHaveBeenCalledWith(unsetAttribute);
-      expect(metadataFormSvc.cleanFormData).toHaveBeenCalledWith(setObject);
     });
 
-    it('cleanFields array behaviour, should only send attributes to be cleaned if they exist', () => {
-      // Given
-      const testCase = {cleanFields: ['missingAttribute', 'unsetAttribute']};
-      const unsetAttribute = cleanTest.unsetAttribute;
-      configureFormAndSvc({config: testCase});
-      fixture.detectChanges();
+    describe('cleanFields false behaviour', () => {
+      [
+        {name: 'false', case: {cleanFields: false}},
+        {name: 'empty Array', case: {cleanFields: []}},
+      ].forEach(test => {
+        it(`cleanFields ${test.name}: should send no data to be cleaned`, () => {
+          // Given
+          configureFormAndSvc({config: test.case});
+          fixture.detectChanges();
 
-      // When
-      component.getFormData();
+          // When
+          component.getFormData();
 
-      // Then
-      expect(metadataFormSvc.cleanFormData).toHaveBeenCalledOnceWith(unsetAttribute);
+          // Then
+          expect(metadataFormSvc.cleanFormData).not.toHaveBeenCalled();
+        });
+      });
+    });
+
+    describe('cleanFields array behaviour', () => {
+      it('should send matching attributes to be cleaned', () => {
+        // Given
+        const unsetAttribute = cleanTest.unsetAttribute;
+        const setObject = cleanTest.setObject;
+        const testCase = {cleanFields: ['unsetAttribute', 'setObject']};
+        configureFormAndSvc({config: testCase});
+        fixture.detectChanges();
+
+        // When
+        component.getFormData();
+
+        // Then
+        expect(metadataFormSvc.cleanFormData).toHaveBeenCalledWith(unsetAttribute);
+        expect(metadataFormSvc.cleanFormData).toHaveBeenCalledWith(setObject);
+      });
+
+      it('should only send attributes to be cleaned if they exist', () => {
+        // Given
+        const testCase = {cleanFields: ['missingAttribute', 'unsetAttribute']};
+        const unsetAttribute = cleanTest.unsetAttribute;
+        configureFormAndSvc({config: testCase});
+        fixture.detectChanges();
+
+        // When
+        component.getFormData();
+
+        // Then
+        expect(metadataFormSvc.cleanFormData).toHaveBeenCalledOnceWith(unsetAttribute);
+      });
     });
   });
 });

--- a/src/app/metadata-schema-form/metadata-form/metadata-form.component.spec.ts
+++ b/src/app/metadata-schema-form/metadata-form/metadata-form.component.spec.ts
@@ -131,14 +131,17 @@ describe('MetadataFormComponent', () => {
       configureFormAndSvc({config: config});
       component.data = cleanTest;
       fixture.detectChanges();
-
-      component.getFormData();
     }
 
     const defaultBehaviourTest = test => {
       it(`cleanAttributes ${test.name} (default) behaviour: send all data to be cleaned`, () => {
+        // Given
         setupCleanAttributesTest(test.value);
 
+        // When
+        component.getFormData();
+
+        // Then
         expect(metadataFormSvc.cleanFormData).toHaveBeenCalledOnceWith(cleanTest);
       });
     };
@@ -151,8 +154,13 @@ describe('MetadataFormComponent', () => {
 
     const falseBehaviourTest = test => {
       it(`cleanAttributes ${test.name} (false) behaviour, send no data to be cleaned`, () => {
+        // Given
         setupCleanAttributesTest(test.value);
 
+        // When
+        component.getFormData();
+
+        // Then
         expect(metadataFormSvc.cleanFormData).not.toHaveBeenCalled();
       });
     };
@@ -163,9 +171,17 @@ describe('MetadataFormComponent', () => {
     ].forEach(falseBehaviourTest);
 
     it('cleanAttributes array behaviour, send matching attributes to be cleaned', () => {
+      // Given
       setupCleanAttributesTest({cleanAttributes: ['unsetAttribute', 'setObject']});
+      const unsetAttribute = cleanTest.unsetAttribute;
+      const setObject = cleanTest.setObject;
 
-      expect(metadataFormSvc.cleanFormData).toHaveBeenCalledWith([cleanTest.unsetAttribute, cleanTest.setObject]);
+      // When
+      component.getFormData();
+
+      // Then
+      expect(metadataFormSvc.cleanFormData).toHaveBeenCalledWith(unsetAttribute);
+      expect(metadataFormSvc.cleanFormData).toHaveBeenCalledWith(setObject);
     });
   });
 });

--- a/src/app/metadata-schema-form/metadata-form/metadata-form.component.ts
+++ b/src/app/metadata-schema-form/metadata-form/metadata-form.component.ts
@@ -121,7 +121,9 @@ export class MetadataFormComponent implements OnInit {
     let formValue = this.metadataForm.formGroup.getRawValue();
     if (Array.isArray(this.config.cleanAttributes)) {
       this.config.cleanAttributes.forEach(attribute => {
-        formValue[attribute] = this.metadataFormService.cleanFormData(formValue[attribute]);
+        if (attribute in formValue) {
+          formValue[attribute] = this.metadataFormService.cleanFormData(formValue[attribute]);
+        }
       });
     } else if (this.config.cleanAttributes !== false) {
       formValue = this.metadataFormService.cleanFormData(formValue);

--- a/src/app/metadata-schema-form/metadata-form/metadata-form.component.ts
+++ b/src/app/metadata-schema-form/metadata-form/metadata-form.component.ts
@@ -141,11 +141,11 @@ export class MetadataFormComponent implements OnInit {
     this.tabChange.emit(this.visibleTabs[tabIndex].key);
   }
 
-  onBack($event: MouseEvent) {
+  onBack() {
     this.back.emit();
   }
 
-  onReset($event: MouseEvent) {
+  onReset() {
     this.reset.emit();
   }
 }

--- a/src/app/metadata-schema-form/metadata-form/metadata-form.component.ts
+++ b/src/app/metadata-schema-form/metadata-form/metadata-form.component.ts
@@ -119,8 +119,12 @@ export class MetadataFormComponent implements OnInit {
 
   getFormData() {
     const formValue = this.metadataForm.formGroup.getRawValue();
-    const formData = this.metadataFormService.cleanFormData(formValue);
-
+    let formData;
+    if (this.config.cleanAttributes === false) {
+      formData = formValue;
+    } else {
+      formData = this.metadataFormService.cleanFormData(formValue);
+    }
     return {
       value: formData,
       valid: this.formGroup.valid,

--- a/src/app/metadata-schema-form/metadata-form/metadata-form.component.ts
+++ b/src/app/metadata-schema-form/metadata-form/metadata-form.component.ts
@@ -80,7 +80,7 @@ export class MetadataFormComponent implements OnInit {
   }
 
   tabIsVisible(tab: MetadataFormTab): boolean {
-    if (this.config.viewMode && this.config.removeEmptyFields && tab.items.length === 1) {
+    if (this.config.viewMode && this.config.hideEmptyFields && tab.items.length === 1) {
       if (tab.key === tab.items[0]) {
         let data = this.data;
         let chain = true;

--- a/src/app/metadata-schema-form/metadata-form/metadata-form.component.ts
+++ b/src/app/metadata-schema-form/metadata-form/metadata-form.component.ts
@@ -119,13 +119,13 @@ export class MetadataFormComponent implements OnInit {
 
   getFormData() {
     let formValue = this.metadataForm.formGroup.getRawValue();
-    if (Array.isArray(this.config.cleanAttributes)) {
-      this.config.cleanAttributes.forEach(attribute => {
+    if (Array.isArray(this.config.cleanFields)) {
+      this.config.cleanFields.forEach(attribute => {
         if (attribute in formValue) {
           formValue[attribute] = this.metadataFormService.cleanFormData(formValue[attribute]);
         }
       });
-    } else if (this.config.cleanAttributes !== false) {
+    } else if (this.config.cleanFields !== false) {
       formValue = this.metadataFormService.cleanFormData(formValue);
     }
     return {

--- a/src/app/metadata-schema-form/metadata-form/metadata-form.component.ts
+++ b/src/app/metadata-schema-form/metadata-form/metadata-form.component.ts
@@ -118,15 +118,16 @@ export class MetadataFormComponent implements OnInit {
   }
 
   getFormData() {
-    const formValue = this.metadataForm.formGroup.getRawValue();
-    let formData;
-    if (this.config.cleanAttributes === false) {
-      formData = formValue;
-    } else {
-      formData = this.metadataFormService.cleanFormData(formValue);
+    let formValue = this.metadataForm.formGroup.getRawValue();
+    if (Array.isArray(this.config.cleanAttributes)) {
+      this.config.cleanAttributes.forEach(attribute => {
+        formValue[attribute] = this.metadataFormService.cleanFormData(formValue[attribute]);
+      });
+    } else if (this.config.cleanAttributes !== false) {
+      formValue = this.metadataFormService.cleanFormData(formValue);
     }
     return {
-      value: formData,
+      value: formValue,
       valid: this.formGroup.valid,
       validationSkipped: this.overrideValidation
     };

--- a/src/app/metadata-schema-form/models/metadata-form-config.ts
+++ b/src/app/metadata-schema-form/models/metadata-form-config.ts
@@ -7,8 +7,8 @@ export interface MetadataFormConfig {
   viewMode?: boolean;
   layout?: MetadataFormLayout;
   inputType?: object;
-  overrideRequiredFields?: {[key: string]: boolean};
-  overrideGuidelines?: {[key: string]: string};
+  overrideRequiredFields?: { [key: string]: boolean };
+  overrideGuidelines?: { [key: string]: string };
   submitButtonLabel?: string;
   cancelButtonLabel?: string;
   showResetButton?: boolean;

--- a/src/app/metadata-schema-form/models/metadata-form-config.ts
+++ b/src/app/metadata-schema-form/models/metadata-form-config.ts
@@ -2,7 +2,7 @@ import {MetadataFormLayout} from './metadata-form-layout';
 
 export interface MetadataFormConfig {
   hideFields?: string[];
-  removeEmptyFields?: boolean;
+  hideEmptyFields?: boolean;
   disableFields?: string[];
   viewMode?: boolean;
   layout?: MetadataFormLayout;

--- a/src/app/metadata-schema-form/models/metadata-form-config.ts
+++ b/src/app/metadata-schema-form/models/metadata-form-config.ts
@@ -4,7 +4,7 @@ export interface MetadataFormConfig {
   hideFields?: string[];
   hideEmptyFields?: boolean;
   disableFields?: string[];
-  cleanAttributes?: boolean | string[];
+  cleanFields?: boolean | string[];
   viewMode?: boolean;
   layout?: MetadataFormLayout;
   inputType?: object;

--- a/src/app/metadata-schema-form/models/metadata-form-config.ts
+++ b/src/app/metadata-schema-form/models/metadata-form-config.ts
@@ -4,6 +4,7 @@ export interface MetadataFormConfig {
   hideFields?: string[];
   hideEmptyFields?: boolean;
   disableFields?: string[];
+  cleanAttributes?: boolean | string[];
   viewMode?: boolean;
   layout?: MetadataFormLayout;
   inputType?: object;

--- a/src/app/metadata-schema-form/models/metadata-registry.ts
+++ b/src/app/metadata-schema-form/models/metadata-registry.ts
@@ -46,7 +46,7 @@ export class MetadataRegistry {
     let isRequired = requiredFields.indexOf(key) >= 0;
     let isHidden = hiddenFields.indexOf(key) >= 0;
     let isDisabled = this.config && this.config.viewMode || disabledFields.indexOf(key) >= 0;
-    const isReadOnly = this.config && this.config.viewMode && this.config.removeEmptyFields;
+    const isReadOnly = this.config && this.config.viewMode && this.config.hideEmptyFields;
     let inputType = this.config && this.config.inputType && this.config.inputType[key] ? this.config.inputType[key] : undefined;
 
     if (metadataKey) {

--- a/src/app/project-summary/project-summary.component.ts
+++ b/src/app/project-summary/project-summary.component.ts
@@ -48,7 +48,7 @@ export class ProjectSummaryComponent implements OnInit {
         this.config = {
           hideFields: ['describedBy', 'schema_version', 'schema_type', 'provenance'],
           viewMode: true,
-          removeEmptyFields: true,
+          hideEmptyFields: true,
           layout: getLayout(false, account.isWrangler())
         };
         this.userAccount = account;

--- a/src/app/project-summary/project-summary.component.ts
+++ b/src/app/project-summary/project-summary.component.ts
@@ -1,6 +1,6 @@
 import {Component, EventEmitter, Input, OnInit, Output} from '@angular/core';
 import {MetadataFormConfig} from '@metadata-schema-form/models/metadata-form-config';
-import {SUBMISSION_STATES} from "@shared/constants";
+import {SUBMISSION_STATES} from '@shared/constants';
 import {Project} from '@shared/models/project';
 import {AlertService} from '@shared/services/alert.service';
 import {IngestService} from '@shared/services/ingest.service';

--- a/src/app/projects/components/project-metadata-form/project-metadata-form.component.ts
+++ b/src/app/projects/components/project-metadata-form/project-metadata-form.component.ts
@@ -194,7 +194,7 @@ export class ProjectMetadataFormComponent implements OnInit, OnDestroy {
         this.project['content']['describedBy'] = schemaUrl;
         this.project['content']['schema_type'] = 'project';
       }),
-      concatMap(schemaUrl => this.schemaService.getDereferencedSchema(this.schemaUrl))
+      concatMap(() => this.schemaService.getDereferencedSchema(this.schemaUrl))
     ).subscribe(schema => {
       this.projectMetadataSchema = schema;
       this.projectIngestSchema['properties']['content'] = this.projectMetadataSchema;

--- a/src/app/projects/components/project-metadata-form/project-metadata-form.component.ts
+++ b/src/app/projects/components/project-metadata-form/project-metadata-form.component.ts
@@ -99,6 +99,7 @@ export class ProjectMetadataFormComponent implements OnInit, OnDestroy {
         'notes': 'textarea',
         'wranglingNotes': 'textarea'
       },
+      cleanFields: ['content'],
       overrideRequiredFields: {
         'project.content.contributors.project_role.text': false
       },

--- a/src/app/projects/components/wrangler-list-input/wrangler-list-input.component.ts
+++ b/src/app/projects/components/wrangler-list-input/wrangler-list-input.component.ts
@@ -37,7 +37,6 @@ export class WranglerListInputComponent extends BaseInputComponent implements On
 
   ngOnInit(): void {
     super.ngOnInit();
-    this.setDefaultWrangler();
     this.searchControl = this.createSearchControl(this.control.value);
     this.wranglers$ = this.ingestService.getWranglers();
     this.options$ = this.searchControl.valueChanges
@@ -66,15 +65,6 @@ export class WranglerListInputComponent extends BaseInputComponent implements On
 
   displayWranglerName(wrangler: Account) {
     return wrangler ? wrangler.name : '';
-  }
-
-  private getWranglerNames(): Observable<string[]> {
-    return this.ingestService.getWranglers().pipe(
-      map(wranglers => wranglers?.map(wrangler => wrangler.name)));
-  }
-
-  private setDefaultWrangler() {
-    // TODO set current account as default wrangler
   }
 
   private onSearchValueChanged(value: string | Account): Observable<Account[]> {

--- a/src/app/projects/components/wrangler-list-input/wrangler-list-input.component.ts
+++ b/src/app/projects/components/wrangler-list-input/wrangler-list-input.component.ts
@@ -51,7 +51,11 @@ export class WranglerListInputComponent extends BaseInputComponent implements On
     const wranglerId = this.control.value;
     if (wranglerId) {
       this.findWrangler(wranglerId).subscribe(wrangler => {
-        this.selectedWrangler = wrangler;
+        if (wrangler) {
+          this.selectedWrangler = wrangler;
+        } else {
+          this.control.setValue(null);
+        }
       });
     }
   }

--- a/src/app/projects/components/wrangler-list-input/wrangler-list-input.component.ts
+++ b/src/app/projects/components/wrangler-list-input/wrangler-list-input.component.ts
@@ -86,12 +86,18 @@ export class WranglerListInputComponent extends BaseInputComponent implements On
       map(matchingWranglers => {
         if (matchingWranglers.length > 0) {
           if (matchingWranglers.length > 1) {
-            this.alertService.warn('Warning', 'Too many wranglers found for this project.');
+            let names: string[] = matchingWranglers.map(wrangler => wrangler.name ? wrangler.name : 'Missing Name');
+            this.alertService.warn(
+              'Multiple Wranglers Match Account',
+              `Multiple wranglers (${names.join(', ')}) match the Account saved against this project: ${accountId}`
+            );
           }
           return matchingWranglers[0];
         }
-        this.alertService.error('Error', 'The wrangler for this project could not be identified.');
-        return null;
+        this.alertService.warn(
+          'No Wranglers Match Account',
+          `No wranglers match the Account saved against this project: ${accountId}`
+        );
       })
     );
   }


### PR DESCRIPTION
fixes for: https://github.com/ebi-ait/dcp-ingest-central/issues/620

- [x] Allow the user to set a project with an assigned wrangler (primary or secondary) to unassigned
- [x] introduce `MetadataFormConfig.cleanAttributes`
- [x] test current (default) behaviour of (send all data to be cleaned) when `MetadataFormConfig.cleanAttributes` is:
    - undefined
    - null
    - true
- [x] Test new behaviour of (send no data to be cleaned) when `MetadataFormConfig.cleanAttributes` is:
    - false
    - empty array
- [x] Implement new behaviour of (send no data to be cleaned)
- [x] Test new behaviour of (send matching attributes to be cleaned) when `MetadataFormConfig.cleanAttributes` is an array
- [x] Implement new behaviour of (send matching attributes to be cleaned)
- [x] Configure Project MetaData Form to only clean the `content` attribute:
    - `config.cleanAttributes = ['content'];`