### PR TITLE
dcp-645 disable spreadsheet tab when importing is ongoing

### DIFF
--- a/src/app/submission/pages/submission.component.html
+++ b/src/app/submission/pages/submission.component.html
@@ -19,7 +19,7 @@
       </button>
       <button mat-icon-button (click)="downloadDetailsOpened=true; selectedIndex=4" [disabled]="!isLinkingDone">
         <mat-icon id="exportToXlsBtn"
-                  [matTooltip]="isLinkingDone ? 'Export submission to .xls file' : 'Linking is in progress. The exporting/importing of .xls file is not yet available.'">
+                  [matTooltip]="isLinkingDone ? 'Export submission to .xls file' : 'Linking is in progress.'">
           get_app
         </mat-icon>
       </button>
@@ -31,17 +31,19 @@
          href="{{submissionEnvelope?._links?.self?.href}}">
         <mat-icon matTooltip="See Ingest API JSON">open_in_new</mat-icon>
       </a>
-      <button mat-icon-button [matMenuTriggerFor]="menu">
-        <mat-icon>more_vert</mat-icon>
-      </button>
-      <mat-menu #menu="matMenu" xPosition="before">
-        <button mat-menu-item (click)="downloadDetailsOpened=true; selectedIndex=4">
-          <span>Generate and Download spreadsheet</span>
+      <ng-container *ngIf="isLinkingDone">
+        <button mat-icon-button [matMenuTriggerFor]="menu">
+          <mat-icon>more_vert</mat-icon>
         </button>
-        <button mat-menu-item (click)="importDetailsOpened=true; selectedIndex=4">
-          <span>Import spreadsheet</span>
-        </button>
-      </mat-menu>
+        <mat-menu #menu="matMenu" xPosition="before">
+          <button mat-menu-item (click)="downloadDetailsOpened=true; selectedIndex=4">
+            <span>Generate and Download spreadsheet</span>
+          </button>
+          <button mat-menu-item (click)="importDetailsOpened=true; selectedIndex=4">
+            <span>Import spreadsheet</span>
+          </button>
+        </mat-menu>
+      </ng-container>
       <app-submission-state [state]="submissionState">{{submissionState}}</app-submission-state>
     </div>
 
@@ -66,7 +68,8 @@
     </div>
   </div>
   <br/>
-  <p  class="vf-u-text-color--red" *ngIf="manifest && !isLinkingDone">Linking is progress: {{percentLinkingDone | number:'.2-2' }}% done </p>
+  <p class="vf-u-text-color--red" *ngIf="manifest && !isLinkingDone">Linking is
+    progress: {{percentLinkingDone | number:'.2-2' }}% done </p>
   <br/>
   <mat-tab-group *ngIf="submissionEnvelopeId" [(selectedIndex)]="selectedIndex">
     <mat-tab label="Biomaterials">
@@ -102,7 +105,7 @@
     <mat-tab [disabled]="!isLinkingDone">
       <ng-template mat-tab-label>
         <label
-          [matTooltip]="isLinkingDone ? 'Export & Import .xls file' : 'Linking is in progress'">
+          [matTooltip]="isLinkingDone ? 'Export or Import spreadsheet' : 'Linking is in progress'">
           Spreadsheet
         </label>
       </ng-template>

--- a/src/app/submission/pages/submission.component.html
+++ b/src/app/submission/pages/submission.component.html
@@ -66,7 +66,7 @@
     </div>
   </div>
   <br/>
-  <p *ngIf="!isLinkingDone">* Linking is in progress: {{percentLinkingDone | number:'.2-2' }}% done </p>
+  <p  class="vf-u-text-color--red" *ngIf="manifest && !isLinkingDone">Linking is progress: {{percentLinkingDone | number:'.2-2' }}% done </p>
   <br/>
   <mat-tab-group *ngIf="submissionEnvelopeId" [(selectedIndex)]="selectedIndex">
     <mat-tab label="Biomaterials">
@@ -99,9 +99,12 @@
       </ng-template>
     </mat-tab>
 
-    <mat-tab [disabled]="!isLinkingDone" >
+    <mat-tab [disabled]="!isLinkingDone">
       <ng-template mat-tab-label>
-        <label  class="labelHeading" [matTooltip]="!isLinkingDone ? 'Not Available when linking is in progress' : 'Export & Import .xls file'">Spreadsheet</label>
+        <label
+          [matTooltip]="isLinkingDone ? 'Export & Import .xls file' : 'Linking is in progress'">
+          Spreadsheet
+        </label>
       </ng-template>
       <ng-template matTabContent>
         <app-spreadsheet-tab-details [projectUuid]="projectUuid"
@@ -132,12 +135,14 @@
     </mat-tab>
 
     <mat-tab
-      label="Validate"
       *ngIf="displayValidateAndSubmitTabs()"
       [disabled]="graphValidationTabDisabled()"
     >
       <ng-template mat-tab-label>
-        <label  class="labelHeading" [matTooltip]="!isLinkingDone ? 'Not Available when linking is in progress' : 'Export & Import .xls file'">Spreadsheet</label>
+        <label class="labelHeading"
+               [matTooltip]="!isLinkingDone ? 'Linking is in progress': undefined">
+          Validate
+        </label>
       </ng-template>
       <h3 class="vf-u-margin__top--xxl vf-text vf-text-heading--4">Graph Validation</h3>
 
@@ -161,7 +166,13 @@
       </ng-template>
     </mat-tab>
 
-    <mat-tab label="Submit" [disabled]="!isValid" *ngIf="displayValidateAndSubmitTabs()">
+    <mat-tab [disabled]="!isValid" *ngIf="displayValidateAndSubmitTabs()">
+      <ng-template mat-tab-label>
+        <label class="labelHeading"
+               [matTooltip]="!isValid ? 'The submission is not valid yet.': undefined">
+          Submit
+        </label>
+      </ng-template>
       <ng-template matTabContent>
         <app-submit
           [project$]="project$"

--- a/src/app/submission/pages/submission.component.html
+++ b/src/app/submission/pages/submission.component.html
@@ -69,7 +69,7 @@
   </div>
   <br/>
   <p class="vf-u-text-color--red" *ngIf="manifest && !isLinkingDone">Linking is
-    progress: {{percentLinkingDone | number:'.2-2' }}% done </p>
+    progress: {{percentLinkingDone | number:'.0-0' }}% done </p>
   <br/>
   <mat-tab-group *ngIf="submissionEnvelopeId" [(selectedIndex)]="selectedIndex">
     <mat-tab label="Biomaterials">

--- a/src/app/submission/pages/submission.component.html
+++ b/src/app/submission/pages/submission.component.html
@@ -17,8 +17,11 @@
           autorenew
         </mat-icon>
       </button>
-      <button mat-icon-button (click)="downloadDetailsOpened=true; selectedIndex=4">
-        <mat-icon id="exportToXlsBtn" matTooltip="Export submission to .xls file">get_app</mat-icon>
+      <button mat-icon-button (click)="downloadDetailsOpened=true; selectedIndex=4" [disabled]="!isLinkingDone">
+        <mat-icon id="exportToXlsBtn"
+                  [matTooltip]="isLinkingDone ? 'Export submission to .xls file' : 'Linking is in progress. The exporting/importing of .xls file is not yet available.'">
+          get_app
+        </mat-icon>
       </button>
       <button mat-icon-button *ngIf="submissionEnvelope && submissionEnvelope.open"
               (click)="onDeleteSubmission(submissionEnvelope)">
@@ -63,6 +66,7 @@
     </div>
   </div>
   <br/>
+  <p *ngIf="!isLinkingDone">* Linking is in progress: {{percentLinkingDone | number:'.2-2' }}% done </p>
   <br/>
   <mat-tab-group *ngIf="submissionEnvelopeId" [(selectedIndex)]="selectedIndex">
     <mat-tab label="Biomaterials">
@@ -95,7 +99,10 @@
       </ng-template>
     </mat-tab>
 
-    <mat-tab label="Spreadsheet">
+    <mat-tab [disabled]="!isLinkingDone" >
+      <ng-template mat-tab-label>
+        <label  class="labelHeading" [matTooltip]="!isLinkingDone ? 'Not Available when linking is in progress' : 'Export & Import .xls file'">Spreadsheet</label>
+      </ng-template>
       <ng-template matTabContent>
         <app-spreadsheet-tab-details [projectUuid]="projectUuid"
                                      [submissionEnvelope]="submissionEnvelope"
@@ -129,6 +136,9 @@
       *ngIf="displayValidateAndSubmitTabs()"
       [disabled]="graphValidationTabDisabled()"
     >
+      <ng-template mat-tab-label>
+        <label  class="labelHeading" [matTooltip]="!isLinkingDone ? 'Not Available when linking is in progress' : 'Export & Import .xls file'">Spreadsheet</label>
+      </ng-template>
       <h3 class="vf-u-margin__top--xxl vf-text vf-text-heading--4">Graph Validation</h3>
 
       <ng-container *ngIf="submissionState !== SUBMISSION_STATES.GraphValid; else graphValid">

--- a/src/app/submission/pages/submission.component.scss
+++ b/src/app/submission/pages/submission.component.scss
@@ -1,4 +1,3 @@
 .mat-basic-chip{
   padding: 7px 12px;
 }
-

--- a/src/app/submission/pages/submission.component.scss
+++ b/src/app/submission/pages/submission.component.scss
@@ -1,3 +1,4 @@
 .mat-basic-chip{
   padding: 7px 12px;
 }
+

--- a/src/app/submission/pages/submission.component.ts
+++ b/src/app/submission/pages/submission.component.ts
@@ -80,6 +80,8 @@ export class SubmissionComponent implements OnInit, OnDestroy {
   importDetailsOpened: boolean;
   downloadDetailsOpened: boolean;
 
+  percentLinkingDone: number;
+
   constructor(
     private alertService: AlertService,
     private ingestService: IngestService,
@@ -149,6 +151,7 @@ export class SubmissionComponent implements OnInit, OnDestroy {
     if (!expectedLinks || (actualLinks === expectedLinks)) {
       this.isLinkingDone = true;
     }
+    this.percentLinkingDone = (actualLinks/expectedLinks) * 100;
   }
 
   displaySubmissionErrors(submissionEnvelope: SubmissionEnvelope) {

--- a/src/app/submission/pages/submission.component.ts
+++ b/src/app/submission/pages/submission.component.ts
@@ -151,7 +151,7 @@ export class SubmissionComponent implements OnInit, OnDestroy {
     if (!expectedLinks || (actualLinks === expectedLinks)) {
       this.isLinkingDone = true;
     }
-    this.percentLinkingDone = (actualLinks/expectedLinks) * 100;
+    this.percentLinkingDone = (actualLinks / expectedLinks) * 100;
   }
 
   displaySubmissionErrors(submissionEnvelope: SubmissionEnvelope) {
@@ -429,13 +429,13 @@ export class SubmissionComponent implements OnInit, OnDestroy {
   }
 
   graphValidationTabDisabled(): boolean {
-    return ![
+    return !(this.isLinkingDone && [
       SUBMISSION_STATES.Valid,
       SUBMISSION_STATES.GraphValid,
       SUBMISSION_STATES.GraphInvalid,
       SUBMISSION_STATES.GraphValidating,
       SUBMISSION_STATES.GraphValidationRequested
-    ].some(state => this.submissionState === state)
+    ].some(state => this.submissionState === state))
   }
 
   triggerGraphValidation(): void {


### PR DESCRIPTION
dcp-645
ebi-ait/dcp-ingest-central#645

**Changes:**
1. Tooltip in export/import icon button
2. Display linking progress - percentage done
3. Tooltip in the Spreadsheet tab label why disabled
4. Disable Validate tab when linking is in progress
5. Tooltip in the Validate tab label why disabled
5. Tooltip in the Submit tab why disabled

<img width="1073" alt="Screenshot 2022-02-17 at 15 20 24" src="https://user-images.githubusercontent.com/31281398/154512605-e5a50930-a7c7-4e3d-9402-8eb4c5d1dd6d.png">

<img width="1085" alt="Screenshot 2022-02-17 at 14 18 44" src="https://user-images.githubusercontent.com/31281398/154500471-94937a86-5bf1-4a7c-ad4f-9ad0ce5abcc8.png">

<img width="1070" alt="Screenshot 2022-02-17 at 15 22 42" src="https://user-images.githubusercontent.com/31281398/154513019-b0eab03d-8c1a-4f1e-aaec-0b84a8cefa07.png">

