### PR TITLE
dcp-792 Add HCA Catalogue to project query

### DIFF
--- a/src/app/projects/components/project-filters/project-filters.component.html
+++ b/src/app/projects/components/project-filters/project-filters.component.html
@@ -121,10 +121,18 @@
       </mat-select>
     </mat-form-field>
 
-  <mat-form-field>
+    <mat-form-field>
       <mat-select placeholder="Labels" formControlName="projectLabels">
         <mat-option>None</mat-option>
         <mat-option *ngFor="let label of projectLabels" [value]="label">{{label}}</mat-option>
+      </mat-select>
+    </mat-form-field>
+
+    <mat-form-field>
+      <mat-select formControlName="hcaCatalogue" placeholder="HCA Catalogue">
+        <mat-option>None</mat-option>
+        <mat-option [value]="true">Yes</mat-option>
+        <mat-option [value]="false">No</mat-option>
       </mat-select>
     </mat-form-field>
   </ng-container>

--- a/src/app/projects/components/project-filters/project-filters.component.ts
+++ b/src/app/projects/components/project-filters/project-filters.component.ts
@@ -43,6 +43,7 @@ export class ProjectFiltersComponent implements OnInit {
     wranglingPriority: [],
     dcpReleaseNumber: [],
     hasOfficialHcaPublication: [],
+    hcaCatalogue: [],
     minCellCount: [{value: 0, disabled: true}],
     maxCellCount: [{value: this.maxCellCount, disabled: true}],
     identifyingOrganism: [],


### PR DESCRIPTION
ZenHub: dcp-792
GitHub: ebi-ait/dcp-ingest-central#792
Dependant on: ebi-ait/ingest-core#136

As a stakeholder, I want to get a list of projects which are Submitted but Catalogue=no, so that we can review and get them updated to show in the Catalog.

- [x] Add HCA Catalogue to project query

![Screenshot 2022-06-29 at 12 21 25](https://user-images.githubusercontent.com/13031259/176425769-05f90990-7938-4609-890a-c5078bcb3aea.png)
y