### PR TITLE
Feature/dcp-999 add duos

### DIFF
--- a/src/app/metadata-schema-form/metadata-field-types/base-input/base-input.component.ts
+++ b/src/app/metadata-schema-form/metadata-field-types/base-input/base-input.component.ts
@@ -45,7 +45,9 @@ export class BaseInputComponent implements OnInit {
       disabled: this.disabled
     };
 
-    this.placeholder = this.metadata.schema.example;
+    if (!this.metadata.ignoreExample) {
+      this.placeholder = this.metadata.schema.example;
+    }
   }
 
   private getHelperText(metadata: Metadata) {

--- a/src/app/metadata-schema-form/models/metadata-form.spec.ts
+++ b/src/app/metadata-schema-form/models/metadata-form.spec.ts
@@ -1,6 +1,7 @@
 import {FormArray, FormControl, FormGroup} from '@angular/forms';
 import {MetadataFormService} from '../metadata-form.service';
 import * as jsonSchema from '../test-json-files/test-json-schema.json';
+import * as jsonSchemaV19 from '../test-json-files/test-json-schema-v19.json';
 import * as json from '../test-json-files/test-json.json';
 import {JsonSchema} from './json-schema';
 import {JsonSchemaProperty} from './json-schema-property';
@@ -9,10 +10,12 @@ import {MetadataFormConfig} from './metadata-form-config';
 
 describe('MetadataForm', () => {
   let testSchema: JsonSchema;
+  let testSchemaV19: JsonSchema;
   let metadataFormSvc: MetadataFormService;
 
   beforeEach(() => {
     testSchema = (jsonSchema as any).default;
+    testSchemaV19 = jsonSchemaV19;
     metadataFormSvc = new MetadataFormService();
   });
 
@@ -205,6 +208,24 @@ describe('MetadataForm', () => {
         'Franck T',
         'Abraham D'
       ]);
+    });
+
+    it('should create FormGroup object without data_use_restriction and ' +
+      'duos_id for schema version 15.0.0', () => {
+      const metadataForm = new MetadataForm('project', testSchema);
+      const formGroup = metadataForm.formGroup;
+
+      expect(formGroup.get('data_use_restriction')).toBeNull();
+      expect(formGroup.get('duos_id')).toBeNull();
+    });
+
+    it('should create FormGroup object with data_use_restriction and ' +
+      'duos_id for schema version 19.0.0', () => {
+      const metadataForm = new MetadataForm('project', testSchemaV19);
+      const formGroup = metadataForm.formGroup;
+
+      expect(formGroup.get('data_use_restriction')).not.toBeNull();
+      expect(formGroup.get('duos_id')).not.toBeNull();
     });
 
   });

--- a/src/app/metadata-schema-form/models/metadata.ts
+++ b/src/app/metadata-schema-form/models/metadata.ts
@@ -18,6 +18,7 @@ export class Metadata {
   childrenMetadata: Metadata[];
 
   itemMetadata: Metadata;
+  ignoreExample: boolean;
 
   constructor(options: {
     schema: JsonSchemaProperty,
@@ -29,7 +30,8 @@ export class Metadata {
     parent?: string,
     children?: string[],
     inputType?: string,
-    guidelines?: string
+    guidelines?: string,
+    ignoreExample?: boolean
   }) {
     this.schema = options.schema;
     this.key = options.key;
@@ -41,6 +43,7 @@ export class Metadata {
     this.childrenMetadata = [];
     this.inputType = options.inputType;
     this.guidelines = options.guidelines;
+    this.ignoreExample = options.ignoreExample || false;
   }
 
   isObjectList(): boolean {

--- a/src/app/metadata-schema-form/test-json-files/test-json-schema-v19.json
+++ b/src/app/metadata-schema-form/test-json-files/test-json-schema-v19.json
@@ -1,0 +1,553 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://schema.staging.data.humancellatlas.org/type/project/19.0.0/project",
+  "description": "A project entity contains information about the overall project.",
+  "additionalProperties": false,
+  "required": [
+    "describedBy",
+    "schema_type",
+    "project_core",
+    "funders",
+    "data_use_restriction"
+  ],
+  "title": "Project",
+  "name": "project",
+  "type": "object",
+  "properties": {
+    "describedBy": {
+      "description": "The URL reference to the schema.",
+      "type": "string",
+      "pattern": "^(http|https)://schema.(.*?)humancellatlas.org/type/project/(([0-9]{1,}.[0-9]{1,}.[0-9]{1,})|([a-zA-Z]*?))/project"
+    },
+    "schema_version": {
+      "description": "The version number of the schema in major.minor.patch format.",
+      "type": "string",
+      "pattern": "^[0-9]{1,}.[0-9]{1,}.[0-9]{1,}$",
+      "example": "4.6.1"
+    },
+    "schema_type": {
+      "description": "The type of the metadata schema entity.",
+      "type": "string",
+      "enum": [
+        "project"
+      ]
+    },
+    "provenance": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "$id": "https://schema.humancellatlas.org/system/1.1.0/provenance",
+      "description": "Provenance information added or generated at time of ingest.",
+      "additionalProperties": false,
+      "required": [
+        "document_id",
+        "submission_date"
+      ],
+      "title": "Provenance",
+      "name": "provenance",
+      "type": "object",
+      "properties": {
+        "describedBy": {
+          "description": "The URL reference to the schema.",
+          "type": "string",
+          "pattern": "^(http|https)://schema.(.*?)humancellatlas.org/system/(([0-9]{1,}.[0-9]{1,}.[0-9]{1,})|([a-zA-Z]*?))/provenance"
+        },
+        "schema_version": {
+          "description": "The version number of the schema in major.minor.patch format.",
+          "type": "string",
+          "pattern": "^[0-9]{1,}.[0-9]{1,}.[0-9]{1,}$",
+          "example": "4.6.1"
+        },
+        "schema_major_version": {
+          "description": "The major version number of the schema.",
+          "type": "integer",
+          "pattern": "^[0-9]{1,}$",
+          "user_friendly": "Schema major version",
+          "example": "4; 10"
+        },
+        "schema_minor_version": {
+          "description": "The minor version number of the schema.",
+          "type": "integer",
+          "pattern": "^[0-9]{1,}$",
+          "user_friendly": "Schema minor version",
+          "example": "6; 15"
+        },
+        "submission_date": {
+          "description": "When project was first submitted to database.",
+          "type": "string",
+          "format": "date-time",
+          "user_friendly": "Submission date"
+        },
+        "submitter_id": {
+          "description": "ID of individual who first submitted project.",
+          "type": "string",
+          "user_friendly": "Submitter ID"
+        },
+        "update_date": {
+          "description": "When project was last updated.",
+          "type": "string",
+          "format": "date-time",
+          "user_friendly": "Update date"
+        },
+        "updater_id": {
+          "description": "ID of individual who last updated project.",
+          "type": "string",
+          "user_friendly": "Updater ID"
+        },
+        "document_id": {
+          "description": "Identifier for document.",
+          "type": "string",
+          "pattern": ".{8}-.{4}-.{4}-.{4}-.{12}",
+          "comment": "This structure supports the current ingest API. It may change in the future.",
+          "user_friendly": "Document ID"
+        },
+        "accession": {
+          "description": "A unique accession for this entity, provided by the broker.",
+          "type": "string",
+          "user_friendly": "Accession"
+        }
+      }
+    },
+    "project_core": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "$id": "https://schema.humancellatlas.org/core/project/7.0.5/project_core",
+      "description": "Information about the project.",
+      "additionalProperties": false,
+      "required": [
+        "project_short_name",
+        "project_title",
+        "project_description"
+      ],
+      "title": "Project core",
+      "name": "project_core",
+      "type": "object",
+      "properties": {
+        "describedBy": {
+          "description": "The URL reference to the schema.",
+          "type": "string",
+          "pattern": "^(http|https)://schema.(.*?)humancellatlas.org/core/project/(([0-9]{1,}.[0-9]{1,}.[0-9]{1,})|([a-zA-Z]*?))/project_core"
+        },
+        "schema_version": {
+          "description": "The version number of the schema in major.minor.patch format.",
+          "type": "string",
+          "pattern": "^[0-9]{1,}.[0-9]{1,}.[0-9]{1,}$",
+          "example": "4.6.1"
+        },
+        "project_short_name": {
+          "description": "A short name for the project.",
+          "type": "string",
+          "example": "CoolOrganProject.",
+          "user_friendly": "Project label",
+          "guidelines": "Project label is a short label by which you refer to the project. It should have no spaces and should be fewer than 50 characters."
+        },
+        "project_title": {
+          "description": "An official title for the project.",
+          "type": "string",
+          "example": "Study of single cells in the human body.",
+          "user_friendly": "Project title",
+          "guidelines": "Project title should be fewer than 30 words, such as a title of a grant proposal or a publication."
+        },
+        "project_description": {
+          "description": "A longer description of the project which includes research goals and experimental approach.",
+          "type": "string",
+          "user_friendly": "Project description",
+          "guidelines": "Project description should be fewer than 300 words, such as an abstract from a grant application or publication."
+        }
+      }
+    },
+    "contributors": {
+      "$schema": "http://json-schema.org/draft-07/schema#",
+      "$id": "https://schema.staging.data.humancellatlas.org/module/project/9.0.0/contact",
+      "description": "Information about an individual who submitted or contributed to a project.",
+      "additionalProperties": false,
+      "required": [
+        "name",
+        "institution"
+      ],
+      "title": "Contact",
+      "name": "contact",
+      "type": "object",
+      "properties": {
+        "describedBy": {
+          "description": "The URL reference to the schema.",
+          "type": "string",
+          "pattern": "^(http|https)://schema.(.*?)humancellatlas.org/module/project/(([0-9]{1,}.[0-9]{1,}.[0-9]{1,})|([a-zA-Z]*?))/contact"
+        },
+        "schema_version": {
+          "description": "The version number of the schema in major.minor.patch format.",
+          "type": "string",
+          "pattern": "^[0-9]{1,}.[0-9]{1,}.[0-9]{1,}$",
+          "example": "4.6.1"
+        },
+        "name": {
+          "description": "Name of individual who has contributed to the project.",
+          "type": "string",
+          "example": "John,D,Doe; Jane,,Smith",
+          "guidelines": "Enter in the format: first name,middle name or initial,last name.",
+          "user_friendly": "Contact name"
+        },
+        "email": {
+          "description": "Email address for the individual.",
+          "type": "string",
+          "example": "dummy@email.com",
+          "format": "email",
+          "user_friendly": "Email address"
+        },
+        "phone": {
+          "description": "Phone number of the individual or their lab.",
+          "type": "string",
+          "example": "(+1) 234-555-6789",
+          "guidelines": "Include the country code.",
+          "user_friendly": "Phone number"
+        },
+        "institution": {
+          "description": "Name of primary institute where the individual works.",
+          "type": "string",
+          "user_friendly": "Institute",
+          "example": "EMBL-EBI; University of Washington"
+        },
+        "laboratory": {
+          "description": "Name of lab or department within the institute where the individual works.",
+          "type": "string",
+          "user_friendly": "Laboratory/Department",
+          "example": "Division of Vaccine Discovery; Department of Biology"
+        },
+        "address": {
+          "description": "Street address where the individual works.",
+          "type": "string",
+          "example": "0000 Main Street, Nowheretown, MA, 12091",
+          "guidelines": "Include street name and number, city, country division, and postal code.",
+          "user_friendly": "Street address"
+        },
+        "country": {
+          "description": "Country where the individual works.",
+          "type": "string",
+          "user_friendly": "Country",
+          "example": "USA"
+        },
+        "corresponding_contributor": {
+          "description": "Whether the individual is a primary point of contact for the project.",
+          "type": "boolean",
+          "user_friendly": "Corresponding contributor",
+          "example": "Should be one of: yes, or no."
+        },
+        "project_role": {
+          "description": "Primary role of the individual in the project.",
+          "type": "object",
+          "$ref": "https://schema.staging.data.humancellatlas.org/module/ontology/2.0.0/contributor_role_ontology",
+          "example": "principal investigator; computational scientist",
+          "user_friendly": "Project role"
+        },
+        "orcid_id": {
+          "description": "The individual's ORCID ID linked to previous work.",
+          "type": "string",
+          "example": "0000-1111-2222-3333",
+          "user_friendly": "ORCID ID"
+        }
+      }
+    },
+    "supplementary_links": {
+      "description": "External link(s) pointing to code, supplementary data files, or analysis files associated with the project which will not be uploaded.",
+      "type": "array",
+      "example": "https://github.com/czbiohub/tabula-muris; http://celltag.org/",
+      "items": {
+        "type": "string"
+      },
+      "user_friendly": "Supplementary link(s)"
+    },
+    "publications": {
+      "description": "Publications resulting from this project.",
+      "type": "array",
+      "items": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$id": "https://schema.staging.data.humancellatlas.org/module/project/7.0.0/publication",
+        "description": "Information about a journal article, book, web page, or other external available documentation for a project.",
+        "additionalProperties": false,
+        "required": [
+          "authors",
+          "title",
+          "official_hca_publication"
+        ],
+        "title": "Publication",
+        "name": "publication",
+        "type": "object",
+        "properties": {
+          "describedBy": {
+            "description": "The URL reference to the schema.",
+            "type": "string",
+            "pattern": "^(http|https)://schema.(.*?)humancellatlas.org/module/project/(([0-9]{1,}.[0-9]{1,}.[0-9]{1,})|([a-zA-Z]*?))/publication"
+          },
+          "schema_version": {
+            "description": "The version number of the schema in major.minor.patch format.",
+            "type": "string",
+            "pattern": "^[0-9]{1,}.[0-9]{1,}.[0-9]{1,}$",
+            "example": "4.6.1"
+          },
+          "authors": {
+            "description": "A list of authors associated with the publication.",
+            "type": "array",
+            "example": "Doe JD",
+            "items": {
+              "type": "string"
+            },
+            "user_friendly": "Authors",
+            "guidelines": "List each author in 'surname initials' format."
+          },
+          "title": {
+            "description": "The title of the publication.",
+            "type": "string",
+            "user_friendly": "Publication title",
+            "example": "Study of single cells in the human body."
+          },
+          "doi": {
+            "description": "The publication digital object identifier (doi) of the publication.",
+            "type": "string",
+            "example": "10.1016/j.cell.2016.07.054",
+            "user_friendly": "Publication DOI"
+          },
+          "pmid": {
+            "description": "The PubMed ID of the publication.",
+            "type": "integer",
+            "example": "27565351",
+            "user_friendly": "Publication PMID"
+          },
+          "url": {
+            "description": "A URL for the publication.",
+            "type": "string",
+            "user_friendly": "Publication URL",
+            "example": "https://www.ncbi.nlm.nih.gov/pmc/articles/PMC5667944/"
+          },
+          "official_hca_publication": {
+            "description": "Has the publication been accepted as an official HCA publication, according to the process described in https://www.humancellatlas.org/publications/ ?",
+            "type": "boolean",
+            "user_friendly": "Official HCA Publication",
+            "guidelines": "Should be one of: yes, or no.",
+            "example": "yes; no"
+          }
+        }
+      },
+      "user_friendly": "Publications"
+    },
+    "hca_bionetworks": {
+      "description": "HCA Bionetworks and Atlases the project is associated with",
+      "type": "array",
+      "items": {
+        "$schema": "http://json-schema.org/draft-07/schema#",
+        "$id": "https://schema.staging.data.humancellatlas.org/module/project/1.0.1/hca_bionetwork",
+        "description": "Information about whether the project is part of a HCA Bionetwork or HCA Atlas.",
+        "additionalProperties": false,
+        "title": "HCA Bionetwork",
+        "name": "hca_bionetwork",
+        "type": "object",
+        "properties": {
+          "describedBy": {
+            "description": "The URL reference to the schema.",
+            "type": "string",
+            "pattern": "^(http|https)://schema.(.*?)humancellatlas.org/module/project/(([0-9]{1,}.[0-9]{1,}.[0-9]{1,})|([a-zA-Z]*?))/contact"
+          },
+          "schema_version": {
+            "description": "The version number of the schema in major.minor.patch format.",
+            "type": "string",
+            "pattern": "^[0-9]+\\.[0-9]+\\.[0-9]+$",
+            "example": "4.6.1"
+          },
+          "name": {
+            "description": "HCA Bionetwork the project is a part of (e.g. Kidney). ",
+            "type": "string",
+            "enum": [
+              "Adipose",
+              "Breast",
+              "Development",
+              "Eye",
+              "Genetic Diversity",
+              "Gut",
+              "Heart",
+              "Immune",
+              "Kidney",
+              "Liver",
+              "Lung",
+              "Musculoskeletal",
+              "Nervous System",
+              "Oral & Craniofacial",
+              "Organoid",
+              "Pancreas",
+              "Reproduction",
+              "Skin"
+            ],
+            "user_friendly": "Official HCA Bionetwork",
+            "guidelines": "Should be one of the networks from https://www.humancellatlas.org/biological-networks/",
+            "example": "Kidney; Lung"
+          },
+          "hca_tissue_atlas": {
+            "description": "A field describing if the project is part of a HCA Tissue Atlas (e.g. Brain Alzheimer Atlas). ",
+            "type": "string",
+            "enum": [
+              "Blood",
+              "Retina",
+              "Lung",
+              "Kidney",
+              "Gut",
+              "Eye",
+              "Brain"
+            ],
+            "user_friendly": "HCA Tissue Atlas",
+            "guidelines": "For example: Blood Atlas",
+            "example": "Blood Atlas"
+          },
+          "hca_tissue_atlas_version": {
+            "description": "A field describing which version of the HCA Tissue Atlas is associated with the project (e.g. v1.0; v2.0)",
+            "type": "string",
+            "pattern": "^v(0|[1-9][0-9]*)\\.(0|[1-9][0-9]*)$",
+            "user_friendly": "Official HCA Tissue Atlas Version",
+            "guidelines": "For example: v1.0; v2.0",
+            "example": "v1.0; v2.0"
+          },
+          "atlas_project": {
+            "description": "A field describing if this project is the HCA Tissue Atlas project which integrates data from other datasets.",
+            "type": "boolean",
+            "user_friendly": "Project Tissue Atlas Status",
+            "guidelines": "Enter ‘Yes’ if this project is one of the HCA Tissue Atlases and it integrates data from all other datasets. Enter ‘No’, if this project's data is being integrated.",
+            "example": "Yes; No"
+          }
+        }
+      },
+      "user_friendly": "HCA Bionetwork(s)"
+    },
+    "insdc_project_accessions": {
+      "description": "An International Nucleotide Sequence Database Collaboration (INSDC) project accession.",
+      "type": "array",
+      "items": {
+        "type": "string",
+        "pattern": "^[D|E|S]RP[0-9]+$"
+      },
+      "example": "SRP000000",
+      "user_friendly": "INSDC project accession",
+      "guidelines": "Enter accession if project has been archived. Accession can be from the DDBJ, NCBI, or EMBL-EBI and must start with DRP, SRP, or ERP, respectively."
+    },
+    "ega_accessions": {
+      "description": "A list of accessions referring to EGA (European Genome-Phenome Archive) datasets or studies.",
+      "type": "array",
+      "items": {
+        "type": "string",
+        "pattern": "^EGA[DS][0-9]{11}$"
+      },
+      "example": "EGAS00000000001; EGAD00000000002",
+      "guidelines": "Enter any EGA study or dataset accessions that relate to the project. Should start with EGAD or EGAS, study accession preferred.",
+      "user_friendly": "EGA Study/Dataset Accession(s)"
+    },
+    "dbgap_accessions": {
+      "description": "A list of database of Genotypes and Phenotypes (dbGaP) study accessions.",
+      "type": "array",
+      "items": {
+        "type": "string",
+        "pattern": "^phs[0-9]{6}(\\.v[0-9])?(\\.p[0-9])?$"
+      },
+      "example": "phs001997.v1.p1; phs001836",
+      "guidelines": "Enter any dbGaP study accessions that relate to this project. Should start with phs, can contain the specific version information.",
+      "user_friendly": "dbGaP Study Accession(s)"
+    },
+    "geo_series_accessions": {
+      "description": "A Gene Expression Omnibus (GEO) series accession.",
+      "type": "array",
+      "items": {
+        "type": "string",
+        "pattern": "^GSE.*$"
+      },
+      "example": "GSE00000",
+      "user_friendly": "GEO series accession",
+      "guidelines": "Enter accession if project has been archived. Accession must start with GSE."
+    },
+    "array_express_accessions": {
+      "description": "An ArrayExpress accession.",
+      "type": "array",
+      "items": {
+        "type": "string",
+        "pattern": "^E-....-.*$"
+      },
+      "example": "E-AAAA-00",
+      "user_friendly": "ArrayExpress accession",
+      "guidelines": "Enter accession if project has been archived. Accession must start with E-."
+    },
+    "insdc_study_accessions": {
+      "description": "An International Nucleotide Sequence Database Collaboration (INSDC) study accession.",
+      "type": "array",
+      "items": {
+        "type": "string",
+        "pattern": "^PRJ[E|N|D][a-zA-Z][0-9]+$"
+      },
+      "example": "PRJNA000000",
+      "user_friendly": "INSDC study accession",
+      "guidelines": "Enter accession if study has been archived. Accession can be from the DDBJ, NCBI, or EMBL-EBI and must start with PRJD, PRJN, or PRJE, respectively."
+    },
+    "biostudies_accessions": {
+      "description": "A BioStudies study accession.",
+      "type": "array",
+      "items": {
+        "type": "string",
+        "pattern": "^S-[A-Z]{4}[0-9]+$"
+      },
+      "example": "S-EXMP1; S-HCAS33",
+      "user_friendly": "BioStudies accession",
+      "guidelines": "Enter accession if study has been archived."
+    },
+    "funders": {
+      "description": "Funding source(s) supporting the project.",
+      "type": "array",
+      "items": {
+        "$ref": "https://schema.staging.data.humancellatlas.org/module/project/2.0.0/funder"
+      },
+      "user_friendly": "Funding source(s)"
+    },
+    "estimated_cell_count": {
+      "description": "An estimated number of cells in this project",
+      "type": "integer",
+      "example": "10000; 2100000",
+      "user_friendly": "Estimated cell count"
+    },
+    "data_use_restriction": {
+      "description": "Data use restrictions that apply to the project.",
+      "type": "string",
+      "enum": [
+        "NRES",
+        "GRU",
+        "GRU-NCU"
+      ],
+      "user_friendly": "Data use restriction",
+      "guidelines": "Must be one of: NRES, GRU, GRU-NCU. The use restriction codes are based on the DUO ontology where NRES corresponds to DUO:0000004, GRU corresponds to DUO:0000042, GRU-NCU corresponds to a combination of DUO:0000042 and DUO:0000046",
+      "example": "GRU"
+    },
+    "duos_id": {
+      "description": "A DUOS dataset id.",
+      "type": "string",
+      "pattern": "^DUOS-\\d{6}$",
+      "example": "DUOS-000108; DUOS-000114",
+      "user_friendly": "DUOS ID",
+      "guidelines": "Managed access projects are registered in DUOS to regulate access. If the project is managed access record the corresponding DUOS ID here."
+    }
+  },
+  "if": {
+    "properties": {
+      "data_use_restriction": {
+        "enum": [
+          "GRU",
+          "GRU-NCU"
+        ]
+      }
+    }
+  },
+  "then": {
+    "required": [
+      "duos_id"
+    ]
+  },
+  "else": {
+    "properties": {
+      "data_use_restriction": {
+        "enum": [
+          "NRES"
+        ]
+      },
+      "duos_id": {
+        "maxLength": 0
+      }
+    }
+  }
+}

--- a/src/app/projects/components/data-use-restriction-group/data-use-restriction-group.component.css
+++ b/src/app/projects/components/data-use-restriction-group/data-use-restriction-group.component.css
@@ -1,0 +1,3 @@
+.vf-form__radio+.vf-form__label {
+  padding: 20px;
+}

--- a/src/app/projects/components/data-use-restriction-group/data-use-restriction-group.component.css
+++ b/src/app/projects/components/data-use-restriction-group/data-use-restriction-group.component.css
@@ -1,3 +1,0 @@
-.vf-form__radio+.vf-form__label {
-  padding: 20px;
-}

--- a/src/app/projects/components/data-use-restriction-group/data-use-restriction-group.component.html
+++ b/src/app/projects/components/data-use-restriction-group/data-use-restriction-group.component.html
@@ -11,12 +11,12 @@
   <!-- Displayed only if 'GRU' or 'GRU-NCU' is selected -->
   <div *ngIf="form.get('data_use_restriction').value === 'GRU' || form.get('data_use_restriction').value === 'GRU-NCU'">
     <app-vf-input
-      [formControl]="duosIdCtrl"
+      formControlName="duos_id"
       [label]="'DUOS ID'"
       [dataType]="'string'"
       [helperText]="'Enter the DUOS dataset ID if the project is registered for managed access.'"
       [isRequired]="true"
-      [error]="showError(duosIdCtrl, 'The DUOS ID must be valid. E.g. DUOS-000108')">
+      [error]="showError(form.get('duos_id'), 'The DUOS ID must be valid. E.g. DUOS-000108')">
     </app-vf-input>
   </div>
 

--- a/src/app/projects/components/data-use-restriction-group/data-use-restriction-group.component.html
+++ b/src/app/projects/components/data-use-restriction-group/data-use-restriction-group.component.html
@@ -11,10 +11,12 @@
   <!-- Displayed only if 'GRU' or 'GRU-NCU' is selected -->
   <div *ngIf="form.get('data_use_restriction').value === 'GRU' || form.get('data_use_restriction').value === 'GRU-NCU'">
     <app-vf-input
-      formControlName="duos_id"
+      [formControl]="duosIdCtrl"
       [label]="'DUOS ID'"
       [dataType]="'string'"
-      [helperText]="'Enter the DUOS dataset ID if the project is registered for managed access.'">
+      [helperText]="'Enter the DUOS dataset ID if the project is registered for managed access.'"
+      [isRequired]="true"
+      [error]="showError(duosIdCtrl, 'The DUOS ID must be valid. E.g. DUOS-000108')">
     </app-vf-input>
   </div>
 

--- a/src/app/projects/components/data-use-restriction-group/data-use-restriction-group.component.html
+++ b/src/app/projects/components/data-use-restriction-group/data-use-restriction-group.component.html
@@ -9,7 +9,7 @@
 
   <!-- Conditional DUOS ID Input Field -->
   <!-- Displayed only if 'GRU' or 'GRU-NCU' is selected -->
-  <div *ngIf="form.get('data_use_restriction').value === 'GRU' || form.get('data_use_restriction').value === 'GRU-NCU'">
+  <div *ngIf="['GRU', 'GRU-NCU'].includes(form.get('data_use_restriction').value)">
     <app-vf-input
       formControlName="duos_id"
       [label]="duosIdLabel"

--- a/src/app/projects/components/data-use-restriction-group/data-use-restriction-group.component.html
+++ b/src/app/projects/components/data-use-restriction-group/data-use-restriction-group.component.html
@@ -1,0 +1,21 @@
+<form [formGroup]="form">
+
+  <!-- Data Use Restriction Dropdown -->
+  <app-metadata-field
+    [metadata]="metadataForm.get('project.content.data_use_restriction')"
+    [control]="metadataForm.getControl('project.content.data_use_restriction')"
+    [id]="'dataUseRestriction'">
+  </app-metadata-field>
+
+  <!-- Conditional DUOS ID Input Field -->
+  <!-- Displayed only if 'GRU' or 'GRU-NCU' is selected -->
+  <div *ngIf="form.get('data_use_restriction').value === 'GRU' || form.get('data_use_restriction').value === 'GRU-NCU'">
+    <app-vf-input
+      formControlName="duos_id"
+      [label]="'DUOS ID'"
+      [dataType]="'string'"
+      [helperText]="'Enter the DUOS dataset ID if the project is registered for managed access.'">
+    </app-vf-input>
+  </div>
+
+</form>

--- a/src/app/projects/components/data-use-restriction-group/data-use-restriction-group.component.html
+++ b/src/app/projects/components/data-use-restriction-group/data-use-restriction-group.component.html
@@ -12,9 +12,9 @@
   <div *ngIf="form.get('data_use_restriction').value === 'GRU' || form.get('data_use_restriction').value === 'GRU-NCU'">
     <app-vf-input
       formControlName="duos_id"
-      [label]="'DUOS ID'"
+      [label]="duosIdLabel"
       [dataType]="'string'"
-      [helperText]="'Enter the DUOS dataset ID if the project is registered for managed access.'"
+      [helperText]="duosIdHelperText"
       [isRequired]="true"
       [error]="showError(form.get('duos_id'), 'The DUOS ID must be valid. E.g. DUOS-000108')">
     </app-vf-input>

--- a/src/app/projects/components/data-use-restriction-group/data-use-restriction-group.component.spec.ts
+++ b/src/app/projects/components/data-use-restriction-group/data-use-restriction-group.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { DataUseRestrictionGroupComponent } from './data-use-restriction-group.component';
+
+describe('DataUseRestrictionGroupComponent', () => {
+  let component: DataUseRestrictionGroupComponent;
+  let fixture: ComponentFixture<DataUseRestrictionGroupComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ DataUseRestrictionGroupComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(DataUseRestrictionGroupComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/projects/components/data-use-restriction-group/data-use-restriction-group.component.spec.ts
+++ b/src/app/projects/components/data-use-restriction-group/data-use-restriction-group.component.spec.ts
@@ -1,25 +1,172 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
-
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import {ReactiveFormsModule, FormBuilder} from '@angular/forms';
 import { DataUseRestrictionGroupComponent } from './data-use-restriction-group.component';
+import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+
+import {MetadataForm} from '@metadata-schema-form/models/metadata-form';
 
 describe('DataUseRestrictionGroupComponent', () => {
   let component: DataUseRestrictionGroupComponent;
   let fixture: ComponentFixture<DataUseRestrictionGroupComponent>;
 
-  beforeEach(async () => {
-    await TestBed.configureTestingModule({
-      declarations: [ DataUseRestrictionGroupComponent ]
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [DataUseRestrictionGroupComponent],
+      imports: [ReactiveFormsModule],
+      providers: [FormBuilder],
+      schemas: [CUSTOM_ELEMENTS_SCHEMA]
     })
-    .compileComponents();
-  });
+      .compileComponents();
+  }));
 
   beforeEach(() => {
+    const schema = {
+      '$schema': 'http://json-schema.org/draft-07/schema#',
+      'additionalProperties': false,
+      'description': 'A ingest project entity contains information about the ingestion of the project.',
+      'name': 'project',
+      'properties': {
+        'identifyingOrganisms': {
+          'description': 'Organism the samples were generated from',
+          'guidelines': 'You can select multiple entries',
+          'type': 'array',
+          'items': {
+            'type': 'string'
+          },
+          'enum': [
+            'Human',
+            'Mouse',
+            'Other'
+          ],
+          'user_friendly': 'Organism the samples were generated from'
+        },
+        'content': {
+          '$id': 'https://schema.dev.data.humancellatlas.org/type/project/19.0.0/project',
+          '$schema': 'http://json-schema.org/draft-07/schema#',
+          'additionalProperties': false,
+          'description': 'A project entity contains information about the overall project.',
+          'name': 'project',
+          'type': 'object',
+          'properties': {
+            'project_core': {
+              '$schema': 'http://json-schema.org/draft-07/schema#',
+              '$id': 'http://schema.dev.data.humancellatlas.org/core/project/7.0.5/project_core',
+              'description': 'Information about the project.',
+              'additionalProperties': false,
+              'required': [
+                'project_short_name'
+              ],
+              'title': 'Project core',
+              'name': 'project_core',
+              'type': 'object',
+              'properties': {
+                'project_short_name': {
+                  'description': 'A short name for the project.',
+                  'type': 'string',
+                  'example': 'CoolOrganProject.',
+                  'user_friendly': 'Project label'
+                }
+              }
+            },
+            "data_use_restriction": {
+              "description": "Data use restrictions that apply to the project.",
+              "type": "string",
+              "enum": [
+                "NRES",
+                "GRU",
+                "GRU-NCU"
+              ],
+              "user_friendly": "Data use restriction",
+              "guidelines": "Must be one of: NRES, GRU, GRU-NCU. The use restriction codes are based on the DUO ontology where NRES corresponds to DUO:0000004, GRU corresponds to DUO:0000042, GRU-NCU corresponds to a combination of DUO:0000042 and DUO:0000046",
+              "example": "GRU"
+            },
+            "duos_id": {
+              "description": "A DUOS dataset id.",
+              "type": "string",
+              "pattern": "^DUOS-\\d{6}$",
+              "example": "DUOS-000108; DUOS-000114",
+              "user_friendly": "DUOS ID",
+              "guidelines": "Managed access projects are registered in DUOS to regulate access. If the project is managed access record the corresponding DUOS ID here."
+            }
+          }
+        }
+      },
+      'required': [],
+      'title': 'Ingest Project',
+      'type': 'object',
+      '$id': ''
+    };
+
+    const metadataForm = new MetadataForm('project', schema);
     fixture = TestBed.createComponent(DataUseRestrictionGroupComponent);
     component = fixture.componentInstance;
+    component.metadataForm = metadataForm;
     fixture.detectChanges();
   });
 
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  describe('duosIdCtrl enabled/disabled based on data_use_restriction value', () => {
+
+    it('should enable duosIdCtrl when data_use_restriction is GRU', () => {
+      component.form.get('data_use_restriction').setValue('GRU');
+      expect(component.form.get('duos_id').enabled).toBeTrue();
+    });
+
+    it('should enable duosIdCtrl when data_use_restriction is GRU-NCU', () => {
+      component.form.get('data_use_restriction').setValue('GRU-NCU');
+      expect(component.form.get('duos_id').enabled).toBeTrue();
+    });
+
+    it('should disable duosIdCtrl when data_use_restriction is NRES', () => {
+      component.form.get('data_use_restriction').setValue('NRES');
+      expect(component.form.get('duos_id').disabled).toBeTrue();
+    });
+
+  });
+
+  describe('duosIdCtrl validators', () => {
+
+    let duosIdControl;
+
+    beforeEach(() => {
+      duosIdControl = component.form.get('duos_id');
+      duosIdControl.enable(); // Make sure control is enabled for validation tests
+    });
+
+    it('should be invalid with a non-matching pattern', () => {
+      duosIdControl.setValue('invalid');
+      expect(duosIdControl.valid).toBeFalse();
+    });
+
+    it('should be valid with a correctly formatted DUOS ID', () => {
+      duosIdControl.setValue('DUOS-123456');
+      expect(duosIdControl.valid).toBeTrue();
+    });
+
+  });
+
+  describe('DataUseRestrictionGroupComponent with ignoreExample', () => {
+    function initializeFormControls(ignoreExample: boolean) {
+      // Simulate initializing form controls based on ignoreExample
+      const exampleValue = ignoreExample ? null : 'GRU';
+      component.metadataForm.formGroup = new FormBuilder().group({
+        'data_use_restriction': [exampleValue]
+      });
+    }
+
+    it('should default to null when ignoreExample is true', () => {
+      initializeFormControls(true);
+      expect(component.metadataForm.formGroup.get('data_use_restriction').value).toBeNull();
+    });
+
+    it('should default to the example value when ignoreExample is false', () => {
+      initializeFormControls(false);
+      expect(component.metadataForm.formGroup.get('data_use_restriction').value).toEqual('GRU');
+    });
+
+  });
+
 });

--- a/src/app/projects/components/data-use-restriction-group/data-use-restriction-group.component.ts
+++ b/src/app/projects/components/data-use-restriction-group/data-use-restriction-group.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit } from '@angular/core';
-import {FormBuilder, FormControl, FormGroup, Validators} from '@angular/forms';
+import {AbstractControl, FormBuilder, FormControl, FormGroup, Validators} from '@angular/forms';
 import { MetadataForm } from '@metadata-schema-form/models/metadata-form';
 import { MetadataFormHelper } from '@metadata-schema-form/models/metadata-form-helper';
 import {first} from "rxjs/operators";
@@ -13,37 +13,32 @@ export class DataUseRestrictionGroupComponent implements OnInit {
   metadataForm: MetadataForm;
   form: FormGroup;
   formHelper: MetadataFormHelper;
-  duosIdCtrl: FormControl;
 
   constructor(private fb: FormBuilder) {}
 
   ngOnInit(): void {
     this.formHelper = new MetadataFormHelper();
     this.initializeForms();
+    this.setDefaultDataUseRestrictionValue();
     this.subscribeToDataUseRestrictionChanges();
   }
 
   initializeForms(): void {
     this.form = this.fb.group({
       data_use_restriction: this.metadataForm.getControl('project.content.data_use_restriction'),
+      duos_id: [{value: '', disabled: true}, Validators.compose([
+        Validators.required,
+        Validators.pattern(/^DUOS-\d{6}$/)
+      ])]
     });
+  }
 
-    // Set default value for `data_use_restriction` immediately after form creation
-    let dataUseRestrictionControl = this.metadataForm.getControl('project.content.data_use_restriction');
-
-    if (!dataUseRestrictionControl) {
-      // Control doesn't exist yet, so we add it
-      this.metadataForm.formGroup.addControl('project.content.data_use_restriction', new FormControl('-'));
-      dataUseRestrictionControl = this.metadataForm.getControl('project.content.data_use_restriction');
-    } else {
-      // Control exists, we just set its initial value
+  setDefaultDataUseRestrictionValue(): void {
+    const dataUseRestrictionControl = this.form.get('data_use_restriction');
+    if (!dataUseRestrictionControl.value) {
+      // Set default value for `data_use_restriction` immediately after form creation
       dataUseRestrictionControl.setValue('null');
     }
-
-    this.duosIdCtrl = new FormControl('', Validators.compose([
-      Validators.required,
-      Validators.pattern(/^DUOS-\d{6}$/)
-    ]));
   }
 
   subscribeToDataUseRestrictionChanges(): void {
@@ -57,7 +52,7 @@ export class DataUseRestrictionGroupComponent implements OnInit {
     });
   }
 
-  showError(control: FormControl, message: string): string {
+  showError(control: AbstractControl, message: string): string {
     if (control.touched && control.errors) {
       const errors = control.errors;
 

--- a/src/app/projects/components/data-use-restriction-group/data-use-restriction-group.component.ts
+++ b/src/app/projects/components/data-use-restriction-group/data-use-restriction-group.component.ts
@@ -1,0 +1,63 @@
+import { Component, OnInit } from '@angular/core';
+import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { MetadataForm } from '@metadata-schema-form/models/metadata-form';
+import { MetadataFormHelper } from '@metadata-schema-form/models/metadata-form-helper';
+import {first} from "rxjs/operators";
+
+@Component({
+  selector: 'app-data-use-restriction-group',
+  templateUrl: './data-use-restriction-group.component.html',
+  styleUrls: ['./data-use-restriction-group.component.css']
+})
+export class DataUseRestrictionGroupComponent implements OnInit {
+  metadataForm: MetadataForm;
+  form: FormGroup;
+  formHelper: MetadataFormHelper;
+
+  constructor(private fb: FormBuilder) {}
+
+  ngOnInit(): void {
+    this.formHelper = new MetadataFormHelper();
+    this.initializeForms();
+    this.subscribeToDataUseRestrictionChanges();
+  }
+
+  initializeForms(): void {
+    this.form = this.fb.group({
+      data_use_restriction: this.metadataForm.getControl('project.content.data_use_restriction'),
+      duos_id: this.metadataForm.getControl('project.content.duos_id')
+    });
+
+    // Check initial value of data_use_restriction and enable/disable duos_id accordingly
+    const dataUseRestrictionValue = this.form.get('data_use_restriction').value;
+    const duosControl = this.form.get('duos_id');
+    console.log("1-dataUseRestrictionValue = " + dataUseRestrictionValue);
+
+    if (dataUseRestrictionValue && duosControl) {
+      dataUseRestrictionValue.valueChanges.pipe(first()).subscribe(value => {
+        console.log("2-dataUseRestrictionValue = " + value);
+        if (value === 'GRU' || value === 'GRU-NCU') {
+          console.log("1-enable");
+          duosControl.enable();
+        } else {
+          duosControl.disable();
+        }
+      });
+    }
+  }
+
+  subscribeToDataUseRestrictionChanges(): void {
+    const dataUseControl = this.form.get('data_use_restriction');
+    if (dataUseControl) {
+      dataUseControl.valueChanges.subscribe(value => {
+        const duosControl = this.form.get('duos_id');
+        if (value === 'GRU' || value === 'GRU-NCU') {
+          console.log("2-enable");
+          duosControl.enable();
+        } else {
+          duosControl.disable();
+        }
+      });
+    }
+  }
+}

--- a/src/app/projects/components/data-use-restriction-group/data-use-restriction-group.component.ts
+++ b/src/app/projects/components/data-use-restriction-group/data-use-restriction-group.component.ts
@@ -48,7 +48,6 @@ export class DataUseRestrictionGroupComponent implements OnInit {
     });
   }
 
-
   subscribeToDataUseRestrictionChanges(): void {
     this.form.get('data_use_restriction').valueChanges.subscribe(value => {
       const duosControl = this.form.get('duos_id');

--- a/src/app/projects/components/data-use-restriction-group/data-use-restriction-group.component.ts
+++ b/src/app/projects/components/data-use-restriction-group/data-use-restriction-group.component.ts
@@ -13,6 +13,7 @@ export class DataUseRestrictionGroupComponent implements OnInit {
   metadataForm: MetadataForm;
   form: FormGroup;
   formHelper: MetadataFormHelper;
+  duosIdCtrl: FormControl;
 
   constructor(private fb: FormBuilder) {}
 
@@ -25,7 +26,6 @@ export class DataUseRestrictionGroupComponent implements OnInit {
   initializeForms(): void {
     this.form = this.fb.group({
       data_use_restriction: this.metadataForm.getControl('project.content.data_use_restriction'),
-      duos_id: this.metadataForm.getControl('project.content.duos_id')
     });
 
     // Set default value for `data_use_restriction` immediately after form creation
@@ -39,19 +39,34 @@ export class DataUseRestrictionGroupComponent implements OnInit {
       // Control exists, we just set its initial value
       dataUseRestrictionControl.setValue('null');
     }
+
+    this.duosIdCtrl = new FormControl('', Validators.compose([
+      Validators.required,
+      Validators.pattern(/^DUOS-\d{6}$/)
+    ]));
   }
 
   subscribeToDataUseRestrictionChanges(): void {
-    const dataUseControl = this.form.get('data_use_restriction');
-    if (dataUseControl) {
-      dataUseControl.valueChanges.subscribe(value => {
-        const duosControl = this.form.get('duos_id');
-        if (value === 'GRU' || value === 'GRU-NCU') {
-          duosControl.enable();
-        } else {
-          duosControl.disable();
-        }
-      });
+    this.form.get('data_use_restriction').valueChanges.subscribe(value => {
+      const duosControl = this.form.get('duos_id');
+      if (value === 'GRU' || value === 'GRU-NCU') {
+        duosControl.enable();
+      } else {
+        duosControl.disable();
+      }
+    });
+  }
+
+  showError(control: FormControl, message: string): string {
+    if (control.touched && control.errors) {
+      const errors = control.errors;
+
+      if (errors['required']) {
+        return 'This field is required';
+      }
+      if (errors['pattern']) {
+        return message;
+      }
     }
   }
 }

--- a/src/app/projects/components/data-use-restriction-group/data-use-restriction-group.component.ts
+++ b/src/app/projects/components/data-use-restriction-group/data-use-restriction-group.component.ts
@@ -1,14 +1,20 @@
 import { Component, OnInit } from '@angular/core';
-import {AbstractControl, FormBuilder, FormControl, FormGroup, Validators} from '@angular/forms';
+import {
+  AbstractControl,
+  FormBuilder,
+  FormGroup,
+  ValidatorFn,
+  Validators
+} from '@angular/forms';
 import { MetadataForm } from '@metadata-schema-form/models/metadata-form';
-import { MetadataFormHelper } from '@metadata-schema-form/models/metadata-form-helper';
-import {first} from "rxjs/operators";
+import { MetadataFormHelper } from '@metadata-schema-form/models/metadata-form-helper'
 
 @Component({
   selector: 'app-data-use-restriction-group',
   templateUrl: './data-use-restriction-group.component.html',
   styleUrls: ['./data-use-restriction-group.component.css']
 })
+
 export class DataUseRestrictionGroupComponent implements OnInit {
   metadataForm: MetadataForm;
   form: FormGroup;
@@ -19,13 +25,22 @@ export class DataUseRestrictionGroupComponent implements OnInit {
   ngOnInit(): void {
     this.formHelper = new MetadataFormHelper();
     this.initializeForms();
-    this.setDefaultDataUseRestrictionValue();
     this.subscribeToDataUseRestrictionChanges();
   }
 
   initializeForms(): void {
+    const dataUseRestrictionMetadata = this.metadataForm.get('project.content.data_use_restriction');
+
+    // Ignore example values for DUO codes
+    if (dataUseRestrictionMetadata) {
+      dataUseRestrictionMetadata.ignoreExample = true;
+    }
+
+    // Get the control for 'data_use_restriction'
+    const dataUseRestrictionControl = this.metadataForm.getControl('project.content.data_use_restriction');
     this.form = this.fb.group({
-      data_use_restriction: this.metadataForm.getControl('project.content.data_use_restriction'),
+      'data_use_restriction': dataUseRestrictionControl,
+
       duos_id: [{value: '', disabled: true}, Validators.compose([
         Validators.required,
         Validators.pattern(/^DUOS-\d{6}$/)
@@ -33,13 +48,6 @@ export class DataUseRestrictionGroupComponent implements OnInit {
     });
   }
 
-  setDefaultDataUseRestrictionValue(): void {
-    const dataUseRestrictionControl = this.form.get('data_use_restriction');
-    if (!dataUseRestrictionControl.value) {
-      // Set default value for `data_use_restriction` immediately after form creation
-      dataUseRestrictionControl.setValue('null');
-    }
-  }
 
   subscribeToDataUseRestrictionChanges(): void {
     this.form.get('data_use_restriction').valueChanges.subscribe(value => {

--- a/src/app/projects/components/data-use-restriction-group/data-use-restriction-group.component.ts
+++ b/src/app/projects/components/data-use-restriction-group/data-use-restriction-group.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit } from '@angular/core';
-import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+import {FormBuilder, FormControl, FormGroup, Validators} from '@angular/forms';
 import { MetadataForm } from '@metadata-schema-form/models/metadata-form';
 import { MetadataFormHelper } from '@metadata-schema-form/models/metadata-form-helper';
 import {first} from "rxjs/operators";
@@ -28,21 +28,16 @@ export class DataUseRestrictionGroupComponent implements OnInit {
       duos_id: this.metadataForm.getControl('project.content.duos_id')
     });
 
-    // Check initial value of data_use_restriction and enable/disable duos_id accordingly
-    const dataUseRestrictionValue = this.form.get('data_use_restriction').value;
-    const duosControl = this.form.get('duos_id');
-    console.log("1-dataUseRestrictionValue = " + dataUseRestrictionValue);
+    // Set default value for `data_use_restriction` immediately after form creation
+    let dataUseRestrictionControl = this.metadataForm.getControl('project.content.data_use_restriction');
 
-    if (dataUseRestrictionValue && duosControl) {
-      dataUseRestrictionValue.valueChanges.pipe(first()).subscribe(value => {
-        console.log("2-dataUseRestrictionValue = " + value);
-        if (value === 'GRU' || value === 'GRU-NCU') {
-          console.log("1-enable");
-          duosControl.enable();
-        } else {
-          duosControl.disable();
-        }
-      });
+    if (!dataUseRestrictionControl) {
+      // Control doesn't exist yet, so we add it
+      this.metadataForm.formGroup.addControl('project.content.data_use_restriction', new FormControl('-'));
+      dataUseRestrictionControl = this.metadataForm.getControl('project.content.data_use_restriction');
+    } else {
+      // Control exists, we just set its initial value
+      dataUseRestrictionControl.setValue('null');
     }
   }
 
@@ -52,7 +47,6 @@ export class DataUseRestrictionGroupComponent implements OnInit {
       dataUseControl.valueChanges.subscribe(value => {
         const duosControl = this.form.get('duos_id');
         if (value === 'GRU' || value === 'GRU-NCU') {
-          console.log("2-enable");
           duosControl.enable();
         } else {
           duosControl.disable();

--- a/src/app/projects/components/data-use-restriction-group/data-use-restriction-group.component.ts
+++ b/src/app/projects/components/data-use-restriction-group/data-use-restriction-group.component.ts
@@ -6,6 +6,7 @@ import {
   ValidatorFn,
   Validators
 } from '@angular/forms';
+import {Metadata} from "@metadata-schema-form/models/metadata";
 import { MetadataForm } from '@metadata-schema-form/models/metadata-form';
 import { MetadataFormHelper } from '@metadata-schema-form/models/metadata-form-helper'
 
@@ -19,6 +20,13 @@ export class DataUseRestrictionGroupComponent implements OnInit {
   metadataForm: MetadataForm;
   form: FormGroup;
   formHelper: MetadataFormHelper;
+  duosIdLabel: string;
+  duosIdHelperText: string;
+
+  private readonly DATA_USE_RESTRICTION_FULL_KEY = 'project.content.data_use_restriction';
+  private readonly DATA_USE_RESTRICTION_FORM_KEY = 'data_use_restriction';
+  private readonly DUOS_ID_FULL_KEY = 'project.content.duos_id';
+  private readonly DUOS_ID_FORM_KEY = 'duos_id';
 
   constructor(private fb: FormBuilder) {}
 
@@ -29,17 +37,16 @@ export class DataUseRestrictionGroupComponent implements OnInit {
   }
 
   initializeForms(): void {
-    const dataUseRestrictionMetadata = this.metadataForm.get('project.content.data_use_restriction');
+    const dataUseRestrictionMetadata = this.metadataForm.get(this.DATA_USE_RESTRICTION_FULL_KEY);
+    this.ignoreExampleValues(dataUseRestrictionMetadata);
 
-    // Ignore example values for DUO codes
-    if (dataUseRestrictionMetadata) {
-      dataUseRestrictionMetadata.ignoreExample = true;
-    }
+    const dataUseRestrictionControl = this.metadataForm.getControl(this.DATA_USE_RESTRICTION_FULL_KEY);
+    const duosIdMetadata = this.metadataForm.get(this.DUOS_ID_FULL_KEY);
+    this.duosIdLabel = duosIdMetadata.schema.user_friendly;
+    this.duosIdHelperText = duosIdMetadata.schema.guidelines;
 
-    // Get the control for 'data_use_restriction'
-    const dataUseRestrictionControl = this.metadataForm.getControl('project.content.data_use_restriction');
     this.form = this.fb.group({
-      'data_use_restriction': dataUseRestrictionControl,
+      [this.DATA_USE_RESTRICTION_FORM_KEY]: dataUseRestrictionControl,
 
       duos_id: [{value: '', disabled: true}, Validators.compose([
         Validators.required,
@@ -48,9 +55,15 @@ export class DataUseRestrictionGroupComponent implements OnInit {
     });
   }
 
+  private ignoreExampleValues(dataUseRestrictionMetadata: Metadata) {
+    if (dataUseRestrictionMetadata) {
+      dataUseRestrictionMetadata.ignoreExample = true;
+    }
+  }
+
   subscribeToDataUseRestrictionChanges(): void {
-    this.form.get('data_use_restriction').valueChanges.subscribe(value => {
-      const duosControl = this.form.get('duos_id');
+    this.form.get(this.DATA_USE_RESTRICTION_FORM_KEY).valueChanges.subscribe(value => {
+      const duosControl = this.form.get(this.DUOS_ID_FORM_KEY);
       if (value === 'GRU' || value === 'GRU-NCU') {
         duosControl.enable();
       } else {

--- a/src/app/projects/components/project-metadata-form/layout.ts
+++ b/src/app/projects/components/project-metadata-form/layout.ts
@@ -1,3 +1,6 @@
+import {
+  DataUseRestrictionGroupComponent
+} from "@projects/components/data-use-restriction-group/data-use-restriction-group.component";
 import {AccessionFieldGroupComponent} from '../accession-field-group/accession-field-group.component';
 import {AdminAreaComponent} from '../admin-area/admin-area.component';
 import {ContactFieldGroupComponent} from '../contact-field-group/contact-field-group.component';
@@ -29,6 +32,13 @@ const getFullLayout = () => ({
         'project.content.project_core.project_title',
         'project.content.project_core.project_description',
         'project.dataAccess',
+        {
+          keys: [
+            'project.content.data_use_restriction',
+            'project.content.duos_id',
+          ],
+          component: DataUseRestrictionGroupComponent
+        },
         {
           keys: [
             'project.identifyingOrganisms',

--- a/src/app/projects/components/project-metadata-form/layout.ts
+++ b/src/app/projects/components/project-metadata-form/layout.ts
@@ -31,7 +31,6 @@ const getFullLayout = () => ({
       items: [
         'project.content.project_core.project_title',
         'project.content.project_core.project_description',
-        'project.dataAccess',
         {
           keys: [
             'project.content.data_use_restriction',

--- a/src/app/projects/components/project-metadata-form/layout.ts
+++ b/src/app/projects/components/project-metadata-form/layout.ts
@@ -31,6 +31,7 @@ const getFullLayout = () => ({
       items: [
         'project.content.project_core.project_title',
         'project.content.project_core.project_description',
+        'project.dataAccess',
         {
           keys: [
             'project.content.data_use_restriction',

--- a/src/app/projects/components/project-metadata-form/project-metadata-form.component.spec.ts
+++ b/src/app/projects/components/project-metadata-form/project-metadata-form.component.spec.ts
@@ -90,10 +90,11 @@ describe('ProjectMetadataFormComponent', () => {
       });
 
       // Should show the ProjectIDComponent and the AccessionFieldGroupComponent
+      // DataUseRestrictionGroupComponent fields were added, increasing the index by 1
       // @ts-ignore
-      expect(projectTab.items.findIndex(item => item?.component === ProjectIdComponent)).toEqual(3);
+      expect(projectTab.items.findIndex(item => item?.component === ProjectIdComponent)).toEqual(4);
       // @ts-ignore
-      expect(projectTab.items.findIndex(item => item?.component === AccessionFieldGroupComponent)).toEqual(4);
+      expect(projectTab.items.findIndex(item => item?.component === AccessionFieldGroupComponent)).toEqual(5);
     });
 
     it('shows correct tabs and fields when not in create mode', () => {

--- a/src/app/projects/projects.module.ts
+++ b/src/app/projects/projects.module.ts
@@ -32,7 +32,7 @@ import {ProjectsRoutingModule} from './projects-routing.module';
 import {DoiService} from './services/doi.service';
 import {ProjectCacheService} from './services/project-cache.service';
 import { AuditLogComponent } from './components/audit-log/audit-log.component';
-
+import { DataUseRestrictionGroupComponent } from './components/data-use-restriction-group/data-use-restriction-group.component';
 @NgModule({
   declarations: [
     AutofillProjectFormComponent,
@@ -53,7 +53,8 @@ import { AuditLogComponent } from './components/audit-log/audit-log.component';
     ContactNameFieldComponent,
     ProjectComponent,
     ProjectSummaryComponent,
-    AuditLogComponent
+    AuditLogComponent,
+    DataUseRestrictionGroupComponent
   ],
   imports: [
     CommonModule,


### PR DESCRIPTION
**Changes Included from Initial Draft**
- Added DUOS code and DUOS id fields from the Project metadata schema into ingest backoffice
- Implemented conditional logic for DUOS id based on selection for data use restriction 
- Implemented validation logic for the added fields, where DUOS id are validated against a given pattern
- Added functionality to selectively ignore schema examples for DUO codes, ensuring the default option is set to blank

**New Changes Since Last Review**
- Refactored code by separating logic into more granular methods
- Utilised schema-based labels and helper texts for DUOS ID field 
- Included test cases to cover the new functionality described above
- Included additional test case into `metadata-form.spec.ts` to validate presence/absence of specific fields based on different schema versions

see ebi-ait/dcp-ingest-central#999